### PR TITLE
Timer reset plus some loop state bugs

### DIFF
--- a/include/xev.h
+++ b/include/xev.h
@@ -77,6 +77,7 @@ void xev_threadpool_batch_push_batch(xev_threadpool_batch* b, xev_threadpool_bat
 int xev_timer_init(xev_watcher *w);
 void xev_timer_deinit(xev_watcher *w);
 void xev_timer_run(xev_watcher *w, xev_loop* loop, xev_completion* c, uint64_t next_ms, void* userdata, xev_timer_cb cb);
+void xev_timer_reset(xev_watcher *w, xev_loop* loop, xev_completion* c, xev_completion *c_cancel, uint64_t next_ms, void* userdata, xev_timer_cb cb);
 void xev_timer_cancel(xev_watcher *w, xev_loop* loop, xev_completion* c, xev_completion* c_cancel, void* userdata, xev_timer_cb cb);
 
 int xev_async_init(xev_watcher *w);

--- a/src/c_api.zig
+++ b/src/c_api.zig
@@ -168,6 +168,46 @@ export fn xev_timer_run(
     }).callback);
 }
 
+export fn xev_timer_reset(
+    v: *xev.Timer,
+    loop: *xev.Loop,
+    c: *xev.Completion,
+    c_cancel: *xev.Completion,
+    next_ms: u64,
+    userdata: ?*anyopaque,
+    cb: *const fn (
+        *xev.Loop,
+        *xev.Completion,
+        c_int,
+        ?*anyopaque,
+    ) callconv(.C) xev.CallbackAction,
+) void {
+    const Callback = @typeInfo(@TypeOf(cb)).Pointer.child;
+    const extern_c = @ptrCast(*Completion, @alignCast(@alignOf(Completion), c));
+    extern_c.c_callback = @ptrCast(*const anyopaque, cb);
+
+    v.reset(loop, c, c_cancel, next_ms, anyopaque, userdata, (struct {
+        fn callback(
+            ud: ?*anyopaque,
+            cb_loop: *xev.Loop,
+            cb_c: *xev.Completion,
+            r: xev.Timer.RunError!void,
+        ) xev.CallbackAction {
+            const cb_extern_c = @ptrCast(*Completion, cb_c);
+            const cb_c_callback = @ptrCast(
+                *const Callback,
+                @alignCast(@alignOf(Callback), cb_extern_c.c_callback),
+            );
+            return @call(.auto, cb_c_callback, .{
+                cb_loop,
+                cb_c,
+                if (r) |_| 0 else |err| errorCode(err),
+                ud,
+            });
+        }
+    }).callback);
+}
+
 export fn xev_timer_cancel(
     v: *xev.Timer,
     loop: *xev.Loop,

--- a/src/heap.zig
+++ b/src/heap.zig
@@ -36,13 +36,6 @@ pub fn Intrusive(
         /// be a member of a single heap at any given time. When compiled
         /// with runtime-safety, assertions will help verify this property.
         pub fn insert(self: *Self, v: *T) void {
-            // In runtime safety modes, we explicitly set pointers to
-            // null on removal from the heap so that we can verify that
-            // values aren't being added to multiple heaps. We only assert
-            // with safety because in non-safe modes we never nullify
-            // the pointers.
-            if (std.debug.runtime_safety) assert(!v.heap.inserted());
-
             self.root = if (self.root) |root| self.meld(v, root) else v;
         }
 
@@ -177,13 +170,6 @@ pub fn IntrusiveField(comptime T: type) type {
         child: ?*T = null,
         prev: ?*T = null,
         next: ?*T = null,
-
-        /// Returns true if this element is inserted into SOME heap.
-        pub fn inserted(self: @This()) bool {
-            return self.child != null or
-                self.prev != null or
-                self.next != null;
-        }
     };
 }
 
@@ -214,11 +200,6 @@ test "heap" {
     h.remove(&d);
 
     const testing = std.testing;
-    try testing.expect(a.heap.inserted());
-    try testing.expect(b.heap.inserted());
-    try testing.expect(c.heap.inserted());
-    try testing.expect(!d.heap.inserted());
-
     try testing.expect(h.deleteMin().?.value == 7);
     try testing.expect(h.deleteMin().?.value == 12);
     try testing.expect(h.deleteMin().?.value == 24);


### PR DESCRIPTION
This adds `timer.reset()` (Zig) and `xev_timer_reset` (C) to reset a timer to run in `next_ms` ms. If the timer was never started, it will be started. If the timer was started but hasn't triggered, it will be reset to trigger in `next_ms` ms. If the timer was started and already triggered, it will restart to trigger in `next_ms` ms.

This also fixes a few completion state bugs the epoll and wasi backends (that are now covered by tests).