### PR TITLE
now() API to retrieve loop time in ms

### DIFF
--- a/include/xev.h
+++ b/include/xev.h
@@ -56,6 +56,8 @@ typedef enum {
 int xev_loop_init(xev_loop* loop);
 void xev_loop_deinit(xev_loop* loop);
 int xev_loop_run(xev_loop* loop, xev_run_mode_t mode);
+int64_t xev_loop_now(xev_loop* loop);
+void xev_loop_update_now(xev_loop* loop);
 
 void xev_completion_zero(xev_completion* c);
 xev_completion_state_t xev_completion_state(xev_completion* c);

--- a/src/c_api.zig
+++ b/src/c_api.zig
@@ -26,6 +26,14 @@ export fn xev_loop_run(loop: *xev.Loop, mode: xev.RunMode) c_int {
     return 0;
 }
 
+export fn xev_loop_now(loop: *xev.Loop) i64 {
+    return loop.now();
+}
+
+export fn xev_loop_update_now(loop: *xev.Loop) void {
+    loop.update_now();
+}
+
 export fn xev_completion_zero(c: *xev.Completion) void {
     c.* = .{};
 }


### PR DESCRIPTION
This is similar to libuv's `uv_now()` or libev's `ev_now()`. This returns the "loop time" in milliseconds. This time is updated once per loop prior to completion polling and can be used to have a monotonic source of time that is consistent through callback excution.

For the io_uring backend, this is lazily calculated because io_uring doesn't actually _need_ a concept of "now" whereas all the other backends do for timers.

C API gets `xev_loop_now(3)` and `xev_loop_update_now(3)`