### PR TITLE
Update Zig, Build API

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -175,9 +175,9 @@ pub fn build(b: *std.Build) !void {
 
     // pkg-config
     {
-        const file = try std.fs.path.join(
+        const file = try b.cache_root.join(
             b.allocator,
-            &[_][]const u8{ b.cache_root, "libxev.pc" },
+            &[_][]const u8{"libxev.pc"}
         );
         const pkgconfig_file = try std.fs.cwd().createFile(file, .{});
 

--- a/src/backend/wasi_poll.zig
+++ b/src/backend/wasi_poll.zig
@@ -1056,7 +1056,7 @@ const Batch = struct {
 
         var b: Batch = .{};
         var cs: [capacity - 1]Completion = undefined;
-        for (cs) |*c, i| {
+        for (cs, 0..) |*c, i| {
             c.* = .{ .op = undefined, .callback = undefined };
             const sub = try b.get(c);
             sub.* = .{ .userdata = @ptrToInt(c), .u = undefined };

--- a/src/build/ScdocStep.zig
+++ b/src/build/ScdocStep.zig
@@ -35,8 +35,7 @@ pub fn init(builder: *Builder) ScdocStep {
         .builder = builder,
         .step = Step.init(.custom, "generate man pages", builder.allocator, make),
         .src_path = builder.pathFromRoot("docs/"),
-        .out_path = fs.path.join(builder.allocator, &[_][]const u8{
-            builder.cache_root,
+        .out_path = builder.cache_root.join(builder.allocator, &[_][]const u8{
             "man",
         }) catch unreachable,
     };


### PR DESCRIPTION
Resolves two build errors in Zig nightly 0.11.0-dev.1817+f6c934677.

1. In the Build API, `cache_root` moved to `Build.Cache.Directory`.
2. The syntax of `for` loops changed in Zig nightly.  Loris Cro has [a comprehensive blog post](https://kristoff.it/blog/zig-multi-sequence-for-loops/) on the change.