### PR TITLE
Log Level incorrectly set in benchmarks

### DIFF
--- a/src/bench/async2.zig
+++ b/src/bench/async2.zig
@@ -1,7 +1,9 @@
 const std = @import("std");
 const run = @import("async1.zig").run;
 
-pub const log_level: std.log.Level = .info;
+pub const std_options = struct {
+    pub const log_level: std.log.Level = .info;
+};
 
 pub fn main() !void {
     try run(2);

--- a/src/bench/async4.zig
+++ b/src/bench/async4.zig
@@ -1,7 +1,9 @@
 const std = @import("std");
 const run = @import("async1.zig").run;
 
-pub const log_level: std.log.Level = .info;
+pub const std_options = struct {
+    pub const log_level: std.log.Level = .info;
+};
 
 pub fn main() !void {
     try run(4);

--- a/src/bench/async8.zig
+++ b/src/bench/async8.zig
@@ -1,7 +1,9 @@
 const std = @import("std");
 const run = @import("async1.zig").run;
 
-pub const log_level: std.log.Level = .info;
+pub const std_options = struct {
+    pub const log_level: std.log.Level = .info;
+};
 
 pub fn main() !void {
     try run(8);

--- a/src/bench/async_pummel_2.zig
+++ b/src/bench/async_pummel_2.zig
@@ -1,7 +1,9 @@
 const std = @import("std");
 const run = @import("async_pummel_1.zig").run;
 
-pub const log_level: std.log.Level = .info;
+pub const std_options = struct {
+    pub const log_level: std.log.Level = .info;
+};
 
 pub fn main() !void {
     try run(2);

--- a/src/bench/async_pummel_4.zig
+++ b/src/bench/async_pummel_4.zig
@@ -1,7 +1,9 @@
 const std = @import("std");
 const run = @import("async_pummel_1.zig").run;
 
-pub const log_level: std.log.Level = .info;
+pub const std_options = struct {
+    pub const log_level: std.log.Level = .info;
+};
 
 pub fn main() !void {
     try run(4);

--- a/src/bench/async_pummel_8.zig
+++ b/src/bench/async_pummel_8.zig
@@ -1,7 +1,9 @@
 const std = @import("std");
 const run = @import("async_pummel_1.zig").run;
 
-pub const log_level: std.log.Level = .info;
+pub const std_options = struct {
+    pub const log_level: std.log.Level = .info;
+};
 
 pub fn main() !void {
     try run(8);


### PR DESCRIPTION
In multithreaded version of async benchmarks, the log level was not set correctly.

This was probably due to a change in the Zig compiler and forgotten to be updated as well.