### PR TITLE
Fix benchmark step storing code in `build.zig`

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -244,7 +244,7 @@ fn benchTargets(
         if (install) c_exe.install();
 
         // Store the mapping
-        try map.put(name, c_exe);
+        try map.put(try b.allocator.dupe(u8, name), c_exe);
     }
 
     return map;


### PR DESCRIPTION
In `build.zig`, in `benchTargets(...)` I came across an issue while building where the `StringHashMap` growing code would reach an `unreachable` codepath.

It was due to the `StringHashMap` being given a local string value that was not copied. Simply making a copy of the string before passing it to the map solved the issue.