### PR TITLE
Windows Backend (IOCP)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,10 +91,10 @@ jobs:
     - name: Install zig
       uses: goto-bus-stop/setup-zig@v2
       with:
-        version: 0.11.0-dev.2154+2089b3f19
+        version: 0.12.0-dev.256+8b74eae9c
 
     - name: test
-      run: zig build test -fsummary
+      run: zig build test --summary all
 
     - name: build all benchmarks and examples
-      run: zig build -Dexample -Dbench -fsummary
+      run: zig build -Dexample -Dbench --summary all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,18 +13,16 @@ jobs:
           x86_64-linux-musl,
           aarch64-macos,
           x86_64-macos,
-          wasm32-wasi
+          wasm32-wasi,
+          x86_64-windows-gnu
 
           # Broken but not in any obvious way:
           # x86-linux-gnu,
           # x86-linux-musl,
-
-          # Not yet supported:
-          # i386-windows,
-          # x86_64-windows-gnu,
+          # x86-windows,
         ]
     runs-on: ${{ matrix.os }}
-    needs: test
+    needs: [test-x86_64-linux, test-x86_64-windows]
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -45,7 +43,7 @@ jobs:
     - name: test
       run: nix develop -c zig build --summary all -Dtarget=${{ matrix.target }}
 
-  test:
+  test-x86_64-linux:
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -77,3 +75,26 @@ jobs:
 
     # Run a full build to ensure that works
     - run: nix build
+
+  test-x86_64-windows:
+    strategy:
+      matrix:
+        os: [windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+        fetch-depth: 0
+
+    - name: Install zig
+      uses: goto-bus-stop/setup-zig@v2
+      with:
+        version: 0.11.0-dev.2154+2089b3f19
+
+    - name: test
+      run: zig build test -fsummary
+
+    - name: build all benchmarks and examples
+      run: zig build -Dexample -Dbench -fsummary

--- a/src/backend/iocp.zig
+++ b/src/backend/iocp.zig
@@ -1,0 +1,1890 @@
+//! Backend to use win32 IOCP.
+const std = @import("std");
+const assert = std.debug.assert;
+const windows = @import("../windows.zig");
+const queue = @import("../queue.zig");
+const heap = @import("../heap.zig");
+const xev = @import("../main.zig").IOCP;
+
+const log = std.log.scoped(.libxev_iocp);
+
+pub const Loop = struct {
+    const TimerHeap = heap.Intrusive(Timer, void, Timer.less);
+
+    /// The handle to the IO completion port.
+    iocp_handle: windows.HANDLE,
+
+    active: usize = 0,
+
+    /// Our queue of submissions that we want to enqueue on the next tick.
+    /// These are NOT started.
+    submissions: queue.Intrusive(Completion) = .{},
+
+    /// The queue of cancellation requests. These will point to the completion that we need to
+    /// cancel. We don't enqueue the exact completion to cancel because it may be in another queue.
+    cancellations: queue.Intrusive(Completion) = .{},
+
+    /// Our queue of completed completions where the callback hasn't been called yet, but the
+    /// "result" field should be set on every completion. This is used to delay completion callbacks
+    /// until the next tick.
+    completions: queue.Intrusive(Completion) = .{},
+
+    /// Heap of timers.
+    timers: TimerHeap = .{ .context = {} },
+
+    /// Cached time
+    cached_now: u64,
+
+    /// Duration of a tick of Windows QueryPerformanceCounter.
+    qpc_duration: u64,
+
+    /// Some internal fields we can pack for better space.
+    flags: packed struct {
+        /// Whether we're in a run of not (to prevent nested runs).
+        in_run: bool = false,
+
+        /// Whether our loop is in a stopped state or not.
+        stopped: bool = false,
+    } = .{},
+
+    /// Initialize a new IOCP-backed event loop. See the Options docs
+    /// for what options matter for IOCP.
+    pub fn init(options: xev.Options) !Loop {
+        _ = options;
+
+        // Get the duration of the QueryPerformanceCounter.
+        // We should check if the division is lossless, but it returns 10_000_000 on my machine so
+        // we'll handle that later.
+        var qpc_duration: u64 = 1_000_000_000 / windows.QueryPerformanceFrequency();
+
+        // This creates a new Completion Port
+        const handle = try windows.CreateIoCompletionPort(windows.INVALID_HANDLE_VALUE, null, 0, 1);
+        var res: Loop = .{
+            .iocp_handle = handle,
+            .qpc_duration = qpc_duration,
+            .cached_now = undefined,
+        };
+
+        res.update_now();
+        return res;
+    }
+
+    /// Deinitialize the loop, this closes the handle to the Completion Port. Any events that were
+    /// unprocessed are lost -- their callbacks will never be called.
+    pub fn deinit(self: *Loop) void {
+        windows.CloseHandle(self.iocp_handle);
+    }
+
+    /// Stop the loop. This can only be called from the main thread.
+    /// This will stop the loop forever. Future ticks will do nothing.
+    ///
+    /// This does NOT stop any completions associated to operations that are in-flight.
+    pub fn stop(self: *Loop) void {
+        self.flags.stopped = true;
+    }
+
+    /// Add a completion to the loop. The completion is not started until the loop is run (`run`) or
+    /// an explicit submission request is made (`submit`).
+    pub fn add(self: *Loop, completion: *Completion) void {
+        if (completion.op == .cancel) {
+            self.start_completion(completion);
+            return;
+        }
+
+        completion.flags.state = .adding;
+        self.submissions.push(completion);
+    }
+
+    /// Submit any enqueued completions. This does not fire any callbacks for completed events
+    /// (success or error). Callbacks are only fired on the next tick.
+    pub fn submit(self: *Loop) !void {
+        // Submit all the submissions. We copy the submission queue so that any resubmits don't
+        // cause an infinite loop.
+        var queued = self.submissions;
+        self.submissions = .{};
+
+        // On error, we have to restore the queue because we may be batching.
+        errdefer self.submissions = queued;
+
+        while (queued.pop()) |c| {
+            switch (c.flags.state) {
+                .adding => self.start_completion(c),
+                .dead => self.stop_completion(c, null),
+                .active => std.log.err(
+                    "invalid state in submission queue state={}",
+                    .{c.flags.state},
+                ),
+            }
+        }
+    }
+
+    /// Process the cancellations queue. This doesn't call any callbacks or perform any syscalls.
+    /// This just shuffles state around and sets things up for cancellation to occur.
+    fn process_cancellations(self: *Loop) void {
+        while (self.cancellations.pop()) |c| {
+            const target = c.op.cancel.c;
+            var cancel_result: CancelError!void = {};
+            switch (target.flags.state) {
+                // If the target is dead already we do nothing.
+                .dead => {},
+
+                // If it is in the submission queue, mark them as dead so they will never be
+                // submitted.
+                .adding => target.flags.state = .dead,
+
+                // If it is active we need to schedule the deletion.
+                .active => self.stop_completion(target, &cancel_result),
+            }
+
+            // We completed the cancellation.
+            c.result = .{ .cancel = cancel_result };
+            self.completions.push(c);
+        }
+    }
+
+    /// Run the event loop. See RunMode documentation for details on modes.
+    /// Once the loop is run, the pointer MUST remain stable.
+    pub fn run(self: *Loop, mode: xev.RunMode) !void {
+        switch (mode) {
+            .no_wait => try self.tick(0),
+            .once => try self.tick(1),
+            .until_done => while (!self.done()) try self.tick(1),
+        }
+    }
+
+    /// Tick through the event loop once, waiting for at least "wait" completions to be processed by
+    /// the loop itself.
+    pub fn tick(self: *Loop, wait: u32) !void {
+        // If we're stopped then the loop is fully over.
+        if (self.flags.stopped) return;
+
+        // We can't nest runs.
+        if (self.flags.in_run) return error.NestedRunsNotAllowed;
+        self.flags.in_run = true;
+        defer self.flags.in_run = false;
+
+        // The list of entry that will be filled with a call to GetQueuedCompletionStatusEx.
+        var entries: [128]windows.OVERLAPPED_ENTRY = undefined;
+
+        var wait_rem = @intCast(usize, wait);
+
+        // Handle all of our cancellations first because we may be able to stop submissions from
+        // even happening if its still queued. Plus, cancellations sometimes add more to the
+        // submission queue.
+        self.process_cancellations();
+
+        // Submit pending completions.
+        try self.submit();
+
+        // Loop condition is inspired from the kqueue backend. See its documentation for details.
+        while (true) {
+            // If we're stopped then the loop is fully over.
+            if (self.flags.stopped) return;
+
+            // We must update our time no matter what.
+            self.update_now();
+
+            const should_continue = (self.active > 0 and (wait == 0 or wait_rem > 0)) or !self.completions.empty();
+            if (!should_continue) break;
+
+            // Run our expired timers.
+            const now_timer: Timer = .{ .next = self.cached_now };
+            while (self.timers.peek()) |t| {
+                if (!Timer.less({}, t, &now_timer)) break;
+
+                // Remove the timer
+                assert(self.timers.deleteMin().? == t);
+
+                // Mark completion as done
+                const c = t.c;
+                c.flags.state = .dead;
+
+                // We mark it as inactive here because if we rearm below the start() function will
+                // reincrement this.
+                self.active -= 1;
+
+                // Lower our remaining count since we have processed something.
+                wait_rem -|= 1;
+
+                // Invoke
+                const action = c.callback(c.userdata, self, c, .{ .timer = .expiration });
+                switch (action) {
+                    .disarm => {},
+                    .rearm => self.start_completion(c),
+                }
+            }
+
+            // Process the completions we already have completed.
+            while (self.completions.pop()) |c| {
+                // We store whether this completion was active so we can decrement the active count
+                // later.
+                const c_active = c.flags.state == .active;
+                c.flags.state = .dead;
+
+                // Decrease our waiters because we are definitely processing one.
+                wait_rem -|= 1;
+
+                // Completion queue items MUST have a result set.
+                const action = c.callback(c.userdata, self, c, c.result.?);
+                switch (action) {
+                    .disarm => {
+                        // If we were active, decrement the number of active completions.
+                        if (c_active) self.active -= 1;
+                    },
+
+                    // Only resubmit if we aren't already active
+                    .rearm => if (!c_active) self.submissions.push(c),
+                }
+            }
+
+            // If we have processed enough event, we break out of the loop.
+            if (wait_rem == 0) break;
+
+            // Determine our next timeout based on the timers.
+            const timeout: ?windows.DWORD = timeout: {
+                // If we have a timer, we want to set the timeout to our next timer value. If we
+                // have no timer, we wait forever.
+                const t = self.timers.peek() orelse break :timeout null;
+
+                // Determin the time in milliseconds. If the cast fails, we fallback to the maximum
+                // acceptable value.
+                const ms_now = self.cached_now / std.time.ns_per_ms;
+                const ms_next = t.next / std.time.ns_per_ms;
+                const ms = ms_next -| ms_now;
+                break :timeout std.math.cast(windows.DWORD, ms) orelse windows.INFINITE - 1;
+            };
+
+            // Wait for changes IO completions.
+            const count: u32 = windows.GetQueuedCompletionStatusEx(self.iocp_handle, &entries, timeout, false) catch |err| switch (err) {
+                // A timeout means that nothing was completed.
+                error.Timeout => 0,
+
+                else => return err,
+            };
+
+            // Go through the entries and perform completions callbacks.
+            for (entries[0..count]) |entry| {
+                // We retrieve the Completion from the OVERLAPPED pointer as we know it's a part of
+                // the Completion struct.
+                const overlapped_ptr: *windows.OVERLAPPED = entry.lpOverlapped;
+                var completion = @fieldParentPtr(Completion, "overlapped", overlapped_ptr);
+
+                wait_rem -|= 1;
+
+                self.active -= 1;
+                completion.flags.state = .dead;
+
+                const result = completion.perform();
+                const action = completion.callback(completion.userdata, self, completion, result);
+                switch (action) {
+                    .disarm => {},
+                    .rearm => @panic("Uh oh"),
+                }
+            }
+
+            // If we ran through the loop once we break if we don't care.
+            if (wait == 0) break;
+        }
+    }
+
+    /// Returns the "loop" time in milliseconds. The loop time is updated once per loop tick, before
+    /// IO polling occurs. It remains constant throughout callback execution.
+    ///
+    /// You can force an update of the "now" value by calling update_now() at any time from the main
+    /// thread.
+    ///
+    /// QueryPerformanceCounter is used to get the current timestamp.
+    pub fn now(self: *Loop) u64 {
+        return self.cached_now;
+    }
+
+    /// Update the cached time.
+    pub fn update_now(self: *Loop) void {
+        // Compute the current timestamp in ms by multiplying the QueryPerfomanceCounter value in
+        // ticks by the duration of a tick.
+        self.cached_now = windows.QueryPerformanceCounter() * self.qpc_duration;
+    }
+
+    /// Add a timer to the loop. The timer will execute in "next_ms". This is oneshot: the timer
+    /// will not repeat. To repeat a timer, either shcedule another in your callback or return rearm
+    /// from the callback.
+    pub fn timer(
+        self: *Loop,
+        c: *Completion,
+        next_ms: u64,
+        userdata: ?*anyopaque,
+        comptime cb: xev.Callback,
+    ) void {
+        c.* = .{
+            .op = .{
+                .timer = .{
+                    .next = self.timer_next(next_ms),
+                },
+            },
+            .userdata = userdata,
+            .callback = cb,
+        };
+
+        self.add(c);
+    }
+
+    /// see io_uring.timer_reset for docs.
+    pub fn timer_reset(
+        self: *Loop,
+        c: *Completion,
+        c_cancel: *Completion,
+        next_ms: u64,
+        userdata: ?*anyopaque,
+        comptime cb: xev.Callback,
+    ) void {
+        switch (c.flags.state) {
+            .dead => {
+                self.timer(c, next_ms, userdata, cb);
+                return;
+            },
+
+            // Adding state we can just modify the metadata and return since the timer isn't in the
+            // heap yet.
+            .adding => {
+                c.op.timer.next = self.timer_next(next_ms);
+                c.userdata = userdata;
+                c.callback = cb;
+            },
+
+            .active => {
+                // Update the reset time for the timer to the desired time along with all the
+                // callbacks.
+                c.op.timer.reset = self.timer_next(next_ms);
+                c.userdata = userdata;
+                c.callback = cb;
+
+                // If the cancellation is active, we assume its for this timer.
+                if (c_cancel.state() == .active) return;
+                assert(c_cancel.state() == .dead and c.state() == .active);
+                c_cancel.* = .{ .op = .{ .cancel = .{ .c = c } } };
+                self.add(c_cancel);
+            },
+        }
+    }
+
+    // Get the absolute timestamp corresponding to the given "next_ms".
+    pub fn timer_next(self: *Loop, next_ms: u64) u64 {
+        return self.cached_now + next_ms * std.time.ns_per_ms;
+    }
+
+    pub fn done(self: *Loop) bool {
+        return self.flags.stopped or (self.active == 0 and
+            self.submissions.empty() and
+            self.completions.empty());
+    }
+
+    // Start the completion.
+    fn start_completion(self: *Loop, completion: *Completion) void {
+        const StartAction = union(enum) {
+            // We successfully submitted the operation.
+            submitted: void,
+
+            // We are a timer.
+            timer: void,
+
+            // We are a cancellation.
+            cancel: void,
+
+            // We have a result code from making a system call now.
+            result: Result,
+        };
+
+        const action: StartAction = switch (completion.op) {
+            .noop => {
+                completion.flags.state = .dead;
+                return;
+            },
+
+            .accept => |*v| action: {
+                var discard: u32 = undefined;
+                const result = windows.ws2_32.AcceptEx(
+                    v.listen_socket,
+                    v.accept_socket,
+                    &v.storage,
+                    0,
+                    @intCast(u32, @sizeOf(std.os.sockaddr.storage) + 16),
+                    @intCast(u32, @sizeOf(std.os.sockaddr.storage) + 16),
+                    &discard,
+                    &completion.overlapped,
+                );
+                if (result != windows.TRUE) {
+                    const err = windows.ws2_32.WSAGetLastError();
+                    break :action switch (err) {
+                        windows.ws2_32.WinsockError.WSA_IO_PENDING => .{ .submitted = {} },
+                        else => .{ .result = .{ .accept = windows.unexpectedWSAError(err) } },
+                    };
+                }
+
+                break :action .{ .submitted = {} };
+            },
+
+            .close => |v| switch (v) {
+                .socket => |s| .{ .result = .{ .close = windows.closesocket(s) catch error.Unexpected } },
+                .handle => |h| .{ .result = .{ .close = windows.CloseHandle(h) } },
+            },
+
+            .connect => |*v| action: {
+                const result = windows.ws2_32.connect(v.socket, &v.addr.any, @intCast(i32, v.addr.getOsSockLen()));
+                if (result != 0) {
+                    const err = windows.ws2_32.WSAGetLastError();
+                    break :action switch (err) {
+                        else => .{ .result = .{ .connect = windows.unexpectedWSAError(err) } },
+                    };
+                }
+                break :action .{ .result = .{ .connect = {} } };
+            },
+
+            .read => |*v| action: {
+                var buffer: []u8 = if (v.buffer == .slice) v.buffer.slice else &v.buffer.array;
+                break :action if (windows.ReadFileW(v.handle, buffer, &completion.overlapped)) |_|
+                    .{
+                        .submitted = {},
+                    }
+                else |err|
+                    .{
+                        .result = .{ .read = err },
+                    };
+            },
+
+            .shutdown => |*v| .{ .result = .{ .shutdown = std.os.shutdown(v.socket, v.how) } },
+
+            .write => |*v| action: {
+                var buffer: []const u8 = if (v.buffer == .slice) v.buffer.slice else v.buffer.array.array[0..v.buffer.array.len];
+                break :action if (windows.WriteFileW(v.handle, buffer, &completion.overlapped)) |_|
+                    .{
+                        .submitted = {},
+                    }
+                else |err|
+                    .{
+                        .result = .{ .write = err },
+                    };
+            },
+
+            .send => |*v| action: {
+                var buffer: []const u8 = if (v.buffer == .slice) v.buffer.slice else v.buffer.array.array[0..v.buffer.array.len];
+                v.wsa_buffer = .{ .buf = @constCast(buffer.ptr), .len = @intCast(u32, buffer.len) };
+                const result = windows.ws2_32.WSASend(
+                    v.socket,
+                    @ptrCast([*]windows.ws2_32.WSABUF, &v.wsa_buffer),
+                    1,
+                    null,
+                    0,
+                    &completion.overlapped,
+                    null,
+                );
+                if (result != 0) {
+                    const err = windows.ws2_32.WSAGetLastError();
+                    break :action switch (err) {
+                        windows.ws2_32.WinsockError.WSA_IO_PENDING => .{ .submitted = {} },
+                        else => .{ .result = .{ .accept = windows.unexpectedWSAError(err) } },
+                    };
+                }
+                break :action .{ .submitted = {} };
+            },
+
+            .recv => |*v| action: {
+                var buffer: []u8 = if (v.buffer == .slice) v.buffer.slice else &v.buffer.array;
+                v.wsa_buffer = .{ .buf = buffer.ptr, .len = @intCast(u32, buffer.len) };
+
+                var flags: u32 = 0;
+
+                const result = windows.ws2_32.WSARecv(
+                    v.socket,
+                    @ptrCast([*]windows.ws2_32.WSABUF, &v.wsa_buffer),
+                    1,
+                    null,
+                    &flags,
+                    &completion.overlapped,
+                    null,
+                );
+                if (result != 0) {
+                    const err = windows.ws2_32.WSAGetLastError();
+                    break :action switch (err) {
+                        windows.ws2_32.WinsockError.WSA_IO_PENDING => .{ .submitted = {} },
+                        else => .{ .result = .{ .accept = windows.unexpectedWSAError(err) } },
+                    };
+                }
+                break :action .{ .submitted = {} };
+            },
+
+            .timer => |*v| action: {
+                v.c = completion;
+                self.timers.insert(v);
+                break :action .{ .timer = {} };
+            },
+
+            .cancel => .{ .cancel = {} },
+        };
+
+        switch (action) {
+            .timer, .submitted => {
+                // Increase our active count so we now wait for this. We assume it'll successfully
+                // queue. If it doesn't we handle that later (see submit).
+                self.active += 1;
+                completion.flags.state = .active;
+            },
+
+            .cancel => {
+                // We are considered an active completion.
+                self.active += 1;
+                completion.flags.state = .active;
+
+                self.cancellations.push(completion);
+            },
+
+            // A result is immediately available. Queue the completion to be invoked.
+            .result => |r| {
+                completion.result = r;
+                self.completions.push(completion);
+            },
+        }
+    }
+
+    fn stop_completion(self: *Loop, completion: *Completion, cancel_result: ?*CancelError!void) void {
+        if (completion.flags.state == .active and completion.result != null) return;
+
+        // Inspect other operations. WARNING: the state can be anything here so per op be sure to
+        // check the state flag.
+        switch (completion.op) {
+            .timer => |*v| {
+                if (completion.flags.state == .active) {
+                    // Remove from the heap so it never fires...
+                    self.timers.remove(v);
+
+                    // If we have reset AND we got cancellation result, that means that we were
+                    // canceled so that we can update our expiration time.
+                    if (v.reset) |r| {
+                        v.next = r;
+                        v.reset = null;
+                        self.active -= 1;
+                        self.add(completion);
+                        return;
+                    }
+                }
+
+                // Add to our completion so we trigger the callback.
+                completion.result = .{ .timer = .cancel };
+                self.completions.push(completion);
+
+                // Note the timers state purposely remains ACTIVE so that
+                // when we process the completion we decrement the
+                // active count.
+            },
+            inline .accept, .recv, .send => {
+                if (completion.flags.state == .active) {
+                    const handle: windows.HANDLE = switch (completion.op) {
+                        .accept => |*v2| v2.listen_socket,
+                        inline .recv, .send => |*v2| v2.socket,
+                        inline .read, .write => |*v2| v2.handle,
+                        else => unreachable,
+                    };
+                    const result = windows.kernel32.CancelIoEx(handle, &completion.overlapped);
+                    cancel_result.?.* = if (result == windows.FALSE)
+                        windows.unexpectedError(windows.kernel32.GetLastError())
+                    else {};
+                }
+            },
+
+            else => @panic("Not implemented"),
+        }
+    }
+
+    /// Associate a handler to the internal completion port.
+    /// This has to be done only once per handle so we delegate the responsibility to the caller.
+    pub fn associate_handle(self: *Loop, handle: windows.HANDLE) !void {
+        _ = try windows.CreateIoCompletionPort(handle, self.iocp_handle, 0, 0);
+    }
+};
+
+/// A completion is a request to perform some work with the loop.
+pub const Completion = struct {
+    /// Operation to execute.
+    op: Operation = .{ .noop = {} },
+
+    /// Userdata and callback for when the completion is finished.
+    userdata: ?*anyopaque = null,
+    callback: xev.Callback = xev.noopCallback,
+
+    //---------------------------------------------------------------
+    // Internal fields
+
+    /// Intrusive queue field.
+    next: ?*Completion = null,
+
+    /// Result code of the syscall. Only used internally in certain scenarios, should not be relied
+    /// upon by program authors.
+    result: ?Result = null,
+
+    flags: packed struct {
+        /// Watch state of this completion. We use this to determine whether we're active, adding or
+        /// dead. This lets us add and abd delete multiple times before a loop tick and handle the
+        /// state properly.
+        state: State = .dead,
+    } = .{},
+
+    /// Win32 OVERLAPPED struct used for asynchronous IO. Only used internally in certain scenarios.
+    /// It needs to be there as we rely on @fieldParentPtr to get the completion using a pointer to
+    /// that field.
+    overlapped: windows.OVERLAPPED = .{
+        .Internal = 0,
+        .InternalHigh = 0,
+        .DUMMYUNIONNAME = .{ .Pointer = null },
+        .hEvent = null,
+    },
+
+    const State = enum(u3) {
+        /// completion is not part of any loop
+        dead = 0,
+
+        /// completion is in the submission queue
+        adding = 1,
+
+        /// completion is submitted successfully
+        active = 3,
+    };
+
+    /// Returns the state of this completion. There are some things to be cautious about when
+    /// calling this function.
+    ///
+    /// First, this is only safe to call from the main thread. This cannot be called from any other
+    /// thread.
+    ///
+    /// Second, if you are using default "undefined" completions, this will NOT return a valid value
+    /// if you access it. You must zero your completion using ".{}". You only need to zero the
+    /// completion once. Once the completion is in use, it will always be valid.
+    ///
+    /// Third, if you stop the loop (loop.stop()), the completions registered with the loop will NOT
+    /// be reset to a dead state.
+    pub fn state(self: Completion) xev.CompletionState {
+        return switch (self.flags.state) {
+            .dead => .dead,
+            .adding, .active => .active,
+        };
+    }
+
+    /// Perform the operation associated with this completion. This will perform the full blocking
+    /// operation for the completion.
+    pub fn perform(self: *Completion) Result {
+        return switch (self.op) {
+            .noop, .close, .connect, .shutdown, .timer, .cancel => {
+                std.log.warn("perform op={s}", .{@tagName(self.op)});
+                unreachable;
+            },
+
+            .accept => |*v| r: {
+                var bytes_transferred: u32 = 0;
+                var flags: u32 = 0;
+                const result = windows.ws2_32.WSAGetOverlappedResult(v.listen_socket, &self.overlapped, &bytes_transferred, windows.FALSE, &flags);
+
+                if (result != windows.TRUE) {
+                    const err = windows.ws2_32.WSAGetLastError();
+                    break :r .{
+                        .accept = switch (err) {
+                            windows.ws2_32.WinsockError.WSA_OPERATION_ABORTED => error.Canceled,
+                            else => windows.unexpectedWSAError(err),
+                        },
+                    };
+                }
+
+                var local_address_ptr: *std.os.sockaddr = undefined;
+                var local_address_len: i32 = @sizeOf(std.os.sockaddr.storage);
+                var remote_address_ptr: *std.os.sockaddr = undefined;
+                var remote_address_len: i32 = @sizeOf(std.os.sockaddr.storage);
+
+                windows.ws2_32.GetAcceptExSockaddrs(
+                    &v.storage,
+                    0,
+                    @intCast(u32, @sizeOf(std.os.sockaddr.storage) + 16),
+                    @intCast(u32, @sizeOf(std.os.sockaddr.storage) + 16),
+                    &local_address_ptr,
+                    &local_address_len,
+                    &remote_address_ptr,
+                    &remote_address_len,
+                );
+
+                break :r .{ .accept = .{
+                    .accept_socket = self.op.accept.accept_socket,
+                    .local_address = std.net.Address.initPosix(@alignCast(4, local_address_ptr)),
+                    .remote_address = std.net.Address.initPosix(@alignCast(4, remote_address_ptr)),
+                } };
+            },
+
+            .read => |*v| r: {
+                var bytes_transferred: windows.DWORD = 0;
+                const result = windows.kernel32.GetOverlappedResult(v.handle, &self.overlapped, &bytes_transferred, windows.FALSE);
+                if (result == windows.FALSE) {
+                    const err = windows.kernel32.GetLastError();
+                    break :r .{ .read = switch (err) {
+                        windows.Win32Error.OPERATION_ABORTED => error.Canceled,
+                        else => error.Unexpected,
+                    } };
+                }
+                break :r .{ .read = @intCast(usize, bytes_transferred) };
+            },
+
+            .write => |*v| r: {
+                var bytes_transferred: windows.DWORD = 0;
+                const result = windows.kernel32.GetOverlappedResult(v.handle, &self.overlapped, &bytes_transferred, windows.FALSE);
+                if (result == windows.FALSE) {
+                    const err = windows.kernel32.GetLastError();
+                    break :r .{ .write = switch (err) {
+                        windows.Win32Error.OPERATION_ABORTED => error.Canceled,
+                        else => error.Unexpected,
+                    } };
+                }
+                break :r .{ .write = @intCast(usize, bytes_transferred) };
+            },
+
+            .send => |*v| r: {
+                var bytes_transferred: u32 = 0;
+                var flags: u32 = 0;
+
+                const result = windows.ws2_32.WSAGetOverlappedResult(v.socket, &self.overlapped, &bytes_transferred, windows.FALSE, &flags);
+
+                if (result != windows.TRUE) {
+                    const err = windows.ws2_32.WSAGetLastError();
+                    break :r .{
+                        .send = switch (err) {
+                            windows.ws2_32.WinsockError.WSA_OPERATION_ABORTED => error.Canceled,
+                            else => windows.unexpectedWSAError(err),
+                        },
+                    };
+                }
+                break :r .{ .send = @intCast(usize, bytes_transferred) };
+            },
+
+            .recv => |*v| r: {
+                var bytes_transferred: u32 = 0;
+                var flags: u32 = 0;
+
+                const result = windows.ws2_32.WSAGetOverlappedResult(v.socket, &self.overlapped, &bytes_transferred, windows.FALSE, &flags);
+
+                if (result != windows.TRUE) {
+                    const err = windows.ws2_32.WSAGetLastError();
+                    break :r .{
+                        .recv = switch (err) {
+                            windows.ws2_32.WinsockError.WSA_OPERATION_ABORTED => error.Canceled,
+                            else => windows.unexpectedWSAError(err),
+                        },
+                    };
+                }
+
+                // NOTE(Corentin): according to Win32 documentation, EOF has to be detected using
+                // the socket type.
+                const socket_type = t: {
+                    var socket_type: windows.DWORD = 0;
+                    var socket_type_bytes = std.mem.asBytes(&socket_type);
+                    var opt_len: i32 = @intCast(i32, socket_type_bytes.len);
+
+                    // Here we assume the call will succeed because the socket should be valid.
+                    std.debug.assert(windows.ws2_32.getsockopt(v.socket, std.os.SOL.SOCKET, std.os.SO.TYPE, socket_type_bytes, &opt_len) == 0);
+                    break :t socket_type;
+                };
+
+                if (socket_type == std.os.SOCK.STREAM and bytes_transferred == 0) {
+                    break :r .{ .recv = error.EOF };
+                }
+
+                break :r .{ .recv = @intCast(usize, bytes_transferred) };
+            },
+        };
+    }
+};
+
+pub const OperationType = enum {
+    /// Do nothing. This operation will not be queued and will never
+    /// have its callback fired. This is NOT equivalent to the io_uring
+    /// "nop" operation.
+    noop,
+
+    /// Accept a connection on a socket.
+    accept,
+
+    /// Close a file descriptor.
+    close,
+
+    /// Initiate a connection on a socket.
+    connect,
+
+    /// Read
+    read,
+
+    /// Shutdown all or part of a full-duplex connection.
+    shutdown,
+
+    /// Write
+    write,
+
+    /// Send
+    send,
+
+    /// Recv
+    recv,
+
+    /// A oneshot or repeating timer. For io_uring, this is implemented
+    /// using the timeout mechanism.
+    timer,
+
+    /// Cancel an existing operation.
+    cancel,
+};
+
+/// All the supported operations of this event loop. These are always
+/// backend-specific and therefore the structure and types change depending
+/// on the underlying system in use. The high level operations are
+/// done by initializing the request handles.
+pub const Operation = union(OperationType) {
+    noop: void,
+
+    accept: struct {
+        listen_socket: windows.ws2_32.SOCKET,
+        accept_socket: windows.ws2_32.SOCKET,
+        storage: [256]u8 = undefined,
+    },
+
+    connect: struct {
+        socket: windows.ws2_32.SOCKET,
+        addr: std.net.Address,
+    },
+
+    close: union(enum) {
+        socket: windows.ws2_32.SOCKET,
+        handle: windows.HANDLE,
+    },
+
+    read: struct {
+        handle: windows.HANDLE,
+        buffer: ReadBuffer,
+    },
+
+    shutdown: struct {
+        socket: windows.ws2_32.SOCKET,
+        how: std.os.ShutdownHow = .both,
+    },
+
+    timer: Timer,
+
+    write: struct {
+        handle: windows.HANDLE,
+        buffer: WriteBuffer,
+    },
+
+    send: struct {
+        socket: windows.ws2_32.SOCKET,
+        buffer: WriteBuffer,
+        wsa_buffer: windows.ws2_32.WSABUF = undefined,
+    },
+
+    recv: struct {
+        socket: windows.ws2_32.SOCKET,
+        buffer: ReadBuffer,
+        wsa_buffer: windows.ws2_32.WSABUF = undefined,
+    },
+
+    cancel: struct {
+        c: *Completion,
+    },
+};
+
+/// The result type based on the operation type. For a callback, the
+/// result tag will ALWAYS match the operation tag.
+pub const Result = union(OperationType) {
+    noop: void,
+    accept: AcceptError!struct {
+        accept_socket: windows.ws2_32.SOCKET,
+        local_address: std.net.Address,
+        remote_address: std.net.Address,
+    },
+    connect: ConnectError!void,
+    close: CloseError!void,
+    read: ReadError!usize,
+    shutdown: ShutdownError!void,
+    timer: TimerError!TimerTrigger,
+    write: WriteError!usize,
+    send: WriteError!usize,
+    recv: ReadError!usize,
+    cancel: CancelError!void,
+};
+
+pub const CancelError = error{
+    Unexpected,
+};
+
+pub const AcceptError = error{
+    Canceled,
+    Unexpected,
+};
+
+pub const CloseError = error{
+    Unexpected,
+};
+
+pub const ConnectError = error{
+    Canceled,
+    Unexpected,
+};
+
+pub const ShutdownError = std.os.ShutdownError || error{
+    Unexpected,
+};
+
+pub const WriteError = windows.WriteFileError || error{
+    Canceled,
+    Unexpected,
+};
+
+pub const ReadError = windows.ReadFileError || error{
+    EOF,
+    Canceled,
+    Unexpected,
+};
+
+pub const AsyncError = error{
+    Unexpected,
+};
+
+pub const TimerError = error{
+    Unexpected,
+};
+
+pub const TimerRemoveError = error{
+    Unexpected,
+};
+
+pub const TimerTrigger = enum {
+    /// Unused with IOCP
+    request,
+
+    /// Timer expired.
+    expiration,
+
+    /// Timer was canceled.
+    cancel,
+};
+
+/// ReadBuffer are the various options for reading.
+pub const ReadBuffer = union(enum) {
+    /// Read into this slice.
+    slice: []u8,
+
+    /// Read into this array, just set this to undefined and it will
+    /// be populated up to the size of the array. This is an option because
+    /// the other union members force a specific size anyways so this lets us
+    /// use the other size in the union to support small reads without worrying
+    /// about buffer allocation.
+    ///
+    /// To know the size read you have to use the return value of the
+    /// read operations (i.e. recv).
+    ///
+    /// Note that the union at the time of this writing could accomodate a
+    /// much larger fixed size array here but we want to retain flexiblity
+    /// for future fields.
+    array: [32]u8,
+
+    // TODO: future will have vectors
+};
+
+/// WriteBuffer are the various options for writing.
+pub const WriteBuffer = union(enum) {
+    /// Write from this buffer.
+    slice: []const u8,
+
+    /// Write from this array. See ReadBuffer.array for why we support this.
+    array: struct {
+        array: [32]u8,
+        len: usize,
+    },
+
+    // TODO: future will have vectors
+};
+
+/// Timer that is inserted into the heap.
+pub const Timer = struct {
+    /// The absolute time to fire this timer next.
+    next: u64,
+
+    /// Only used internally. If this is non-null and timer is
+    /// CANCELLED, then the timer is rearmed automatically with this
+    /// as the next time. The callback will not be called on the
+    /// cancellation.
+    reset: ?u64 = null,
+
+    /// Internal heap field.
+    heap: heap.IntrusiveField(Timer) = .{},
+
+    /// We point back to completion for now. When issue[1] is fixed,
+    /// we can juse use that from our heap fields.
+    /// [1]: https://github.com/ziglang/zig/issues/6611
+    c: *Completion = undefined,
+
+    fn less(_: void, a: *const Timer, b: *const Timer) bool {
+        return a.next < b.next;
+    }
+};
+
+test "iocp: loop time" {
+    const testing = std.testing;
+
+    var loop = try Loop.init(.{});
+    defer loop.deinit();
+
+    // should never init zero
+    var now = loop.now();
+    try testing.expect(now > 0);
+
+    while (now == loop.now()) try loop.run(.no_wait);
+}
+test "iocp: stop" {
+    const testing = std.testing;
+
+    var loop = try Loop.init(.{});
+    defer loop.deinit();
+
+    // Add the timer
+    var called = false;
+    var c1: Completion = undefined;
+    loop.timer(&c1, 1_000_000, &called, (struct {
+        fn callback(ud: ?*anyopaque, l: *xev.Loop, _: *xev.Completion, r: xev.Result) xev.CallbackAction {
+            _ = l;
+            _ = r;
+            const b = @ptrCast(*bool, ud.?);
+            b.* = true;
+            return .disarm;
+        }
+    }).callback);
+
+    // Tick
+    try loop.run(.no_wait);
+    try testing.expect(!called);
+
+    // Stop
+    loop.stop();
+    try loop.run(.until_done);
+    try testing.expect(!called);
+}
+
+test "iocp: timer" {
+    const testing = std.testing;
+
+    var loop = try Loop.init(.{});
+    defer loop.deinit();
+
+    // Add the timer
+    var called = false;
+    var c1: xev.Completion = undefined;
+    loop.timer(&c1, 1, &called, (struct {
+        fn callback(
+            ud: ?*anyopaque,
+            l: *xev.Loop,
+            _: *xev.Completion,
+            r: xev.Result,
+        ) xev.CallbackAction {
+            _ = l;
+            _ = r;
+            const b = @ptrCast(*bool, ud.?);
+            b.* = true;
+            return .disarm;
+        }
+    }).callback);
+
+    // Add another timer
+    var called2 = false;
+    var c2: xev.Completion = undefined;
+    loop.timer(&c2, 100_000, &called2, (struct {
+        fn callback(
+            ud: ?*anyopaque,
+            l: *xev.Loop,
+            _: *xev.Completion,
+            r: xev.Result,
+        ) xev.CallbackAction {
+            _ = l;
+            _ = r;
+            const b = @ptrCast(*bool, ud.?);
+            b.* = true;
+            return .disarm;
+        }
+    }).callback);
+
+    // State checking
+    try testing.expect(c1.state() == .active);
+    try testing.expect(c2.state() == .active);
+
+    // Tick
+    while (!called) try loop.run(.no_wait);
+    try testing.expect(called);
+    try testing.expect(!called2);
+
+    // State checking
+    try testing.expect(c1.state() == .dead);
+    try testing.expect(c2.state() == .active);
+}
+
+test "iocp: timer reset" {
+    const testing = std.testing;
+
+    var loop = try Loop.init(.{});
+    defer loop.deinit();
+
+    const cb: xev.Callback = (struct {
+        fn callback(
+            ud: ?*anyopaque,
+            l: *xev.Loop,
+            _: *xev.Completion,
+            r: xev.Result,
+        ) xev.CallbackAction {
+            _ = l;
+            const v = @ptrCast(*?TimerTrigger, ud.?);
+            v.* = r.timer catch unreachable;
+            return .disarm;
+        }
+    }).callback;
+
+    // Add the timer
+    var trigger: ?TimerTrigger = null;
+    var c1: Completion = undefined;
+    loop.timer(&c1, 100_000, &trigger, cb);
+
+    // We know timer won't be called from the timer test previously.
+    try loop.run(.no_wait);
+    try testing.expect(trigger == null);
+
+    // Reset the timer
+    var c_cancel: Completion = .{};
+    loop.timer_reset(&c1, &c_cancel, 1, &trigger, cb);
+    try testing.expect(c1.state() == .active);
+    try testing.expect(c_cancel.state() == .active);
+
+    // Run
+    try loop.run(.until_done);
+    try testing.expect(trigger.? == .expiration);
+    try testing.expect(c1.state() == .dead);
+    try testing.expect(c_cancel.state() == .dead);
+}
+
+test "iocp: timer reset before tick" {
+    const testing = std.testing;
+
+    var loop = try Loop.init(.{});
+    defer loop.deinit();
+
+    const cb: xev.Callback = (struct {
+        fn callback(
+            ud: ?*anyopaque,
+            l: *xev.Loop,
+            _: *xev.Completion,
+            r: xev.Result,
+        ) xev.CallbackAction {
+            _ = l;
+            const v = @ptrCast(*?TimerTrigger, ud.?);
+            v.* = r.timer catch unreachable;
+            return .disarm;
+        }
+    }).callback;
+
+    // Add the timer
+    var trigger: ?TimerTrigger = null;
+    var c1: Completion = undefined;
+    loop.timer(&c1, 100_000, &trigger, cb);
+
+    // Reset the timer
+    var c_cancel: Completion = .{};
+    loop.timer_reset(&c1, &c_cancel, 1, &trigger, cb);
+    try testing.expect(c1.state() == .active);
+    try testing.expect(c_cancel.state() == .dead);
+
+    // Run
+    try loop.run(.until_done);
+    try testing.expect(trigger.? == .expiration);
+    try testing.expect(c1.state() == .dead);
+    try testing.expect(c_cancel.state() == .dead);
+}
+
+test "iocp: timer reset after trigger" {
+    const testing = std.testing;
+
+    var loop = try Loop.init(.{});
+    defer loop.deinit();
+
+    const cb: xev.Callback = (struct {
+        fn callback(
+            ud: ?*anyopaque,
+            l: *xev.Loop,
+            _: *xev.Completion,
+            r: xev.Result,
+        ) xev.CallbackAction {
+            _ = l;
+            const v = @ptrCast(*?TimerTrigger, ud.?);
+            v.* = r.timer catch unreachable;
+            return .disarm;
+        }
+    }).callback;
+
+    // Add the timer
+    var trigger: ?TimerTrigger = null;
+    var c1: Completion = undefined;
+    loop.timer(&c1, 1, &trigger, cb);
+
+    // Run the timer
+    try loop.run(.until_done);
+    try testing.expect(trigger.? == .expiration);
+    try testing.expect(c1.state() == .dead);
+    trigger = null;
+
+    // Reset the timer
+    var c_cancel: Completion = .{};
+    loop.timer_reset(&c1, &c_cancel, 1, &trigger, cb);
+    try testing.expect(c1.state() == .active);
+    try testing.expect(c_cancel.state() == .dead);
+
+    // Run
+    try loop.run(.until_done);
+    try testing.expect(trigger.? == .expiration);
+    try testing.expect(c1.state() == .dead);
+    try testing.expect(c_cancel.state() == .dead);
+}
+
+test "iocp: timer cancellation" {
+    const testing = std.testing;
+
+    var loop = try Loop.init(.{});
+    defer loop.deinit();
+
+    // Add the timer
+    var trigger: ?TimerTrigger = null;
+    var c1: xev.Completion = undefined;
+    loop.timer(&c1, 100_000, &trigger, (struct {
+        fn callback(
+            ud: ?*anyopaque,
+            l: *xev.Loop,
+            _: *xev.Completion,
+            r: xev.Result,
+        ) xev.CallbackAction {
+            _ = l;
+            const ptr = @ptrCast(*?TimerTrigger, @alignCast(@alignOf(?TimerTrigger), ud.?));
+            ptr.* = r.timer catch unreachable;
+            return .disarm;
+        }
+    }).callback);
+
+    // Tick and verify we're not called.
+    try loop.run(.no_wait);
+    try testing.expect(trigger == null);
+
+    // Cancel the timer
+    var called = false;
+    var c_cancel: xev.Completion = .{
+        .op = .{
+            .cancel = .{
+                .c = &c1,
+            },
+        },
+
+        .userdata = &called,
+        .callback = (struct {
+            fn callback(
+                ud: ?*anyopaque,
+                l: *xev.Loop,
+                c: *xev.Completion,
+                r: xev.Result,
+            ) xev.CallbackAction {
+                _ = l;
+                _ = c;
+                _ = r.cancel catch unreachable;
+                const ptr = @ptrCast(*bool, @alignCast(@alignOf(bool), ud.?));
+                ptr.* = true;
+                return .disarm;
+            }
+        }).callback,
+    };
+    loop.add(&c_cancel);
+
+    // Tick
+    try loop.run(.until_done);
+    try testing.expect(called);
+    try testing.expect(trigger.? == .cancel);
+}
+
+test "iocp: canceling a completed operation" {
+    const testing = std.testing;
+
+    var loop = try Loop.init(.{});
+    defer loop.deinit();
+
+    // Add the timer
+    var trigger: ?TimerTrigger = null;
+    var c1: xev.Completion = undefined;
+    loop.timer(&c1, 1, &trigger, (struct {
+        fn callback(
+            ud: ?*anyopaque,
+            l: *xev.Loop,
+            _: *xev.Completion,
+            r: xev.Result,
+        ) xev.CallbackAction {
+            _ = l;
+            const ptr = @ptrCast(*?TimerTrigger, @alignCast(@alignOf(?TimerTrigger), ud.?));
+            ptr.* = r.timer catch unreachable;
+            return .disarm;
+        }
+    }).callback);
+
+    // Tick and verify we're not called.
+    try loop.run(.until_done);
+    try testing.expect(trigger.? == .expiration);
+
+    // Cancel the timer
+    var called = false;
+    var c_cancel: xev.Completion = .{
+        .op = .{
+            .cancel = .{
+                .c = &c1,
+            },
+        },
+
+        .userdata = &called,
+        .callback = (struct {
+            fn callback(
+                ud: ?*anyopaque,
+                l: *xev.Loop,
+                c: *xev.Completion,
+                r: xev.Result,
+            ) xev.CallbackAction {
+                _ = l;
+                _ = c;
+                _ = r.cancel catch unreachable;
+                const ptr = @ptrCast(*bool, @alignCast(@alignOf(bool), ud.?));
+                ptr.* = true;
+                return .disarm;
+            }
+        }).callback,
+    };
+    loop.add(&c_cancel);
+
+    // Tick
+    try loop.run(.until_done);
+    try testing.expect(called);
+    try testing.expect(trigger.? == .expiration);
+}
+
+test "iocp: noop" {
+    var loop = try Loop.init(.{});
+    defer loop.deinit();
+
+    var c: Completion = .{};
+    loop.add(&c);
+
+    try loop.run(.once);
+}
+
+fn openTempFile(name: [:0]const u16) !windows.HANDLE {
+    const result = windows.CreateFile(name, windows.GENERIC_READ | windows.GENERIC_WRITE, 0, null, windows.OPEN_ALWAYS, windows.FILE_FLAG_OVERLAPPED, null);
+
+    return result;
+}
+
+test "iocp: file IO" {
+    const testing = std.testing;
+
+    var loop = try Loop.init(.{});
+    defer loop.deinit();
+
+    const utf16_file_name = (try windows.sliceToPrefixedFileW("test_watcher_file")).span();
+
+    const f_handle = try windows.CreateFile(utf16_file_name, windows.GENERIC_READ | windows.GENERIC_WRITE, 0, null, windows.OPEN_ALWAYS, windows.FILE_FLAG_OVERLAPPED, null);
+    defer windows.DeleteFileW(utf16_file_name) catch {};
+    defer windows.CloseHandle(f_handle);
+
+    try loop.associate_handle(f_handle);
+
+    // Perform a write and then a read
+    var write_buf = [_]u8{ 1, 1, 2, 3, 5, 8, 13 };
+    var c_write: xev.Completion = .{
+        .op = .{
+            .write = .{
+                .handle = f_handle,
+                .buffer = .{ .slice = &write_buf },
+            },
+        },
+        .callback = (struct {
+            fn callback(
+                ud: ?*anyopaque,
+                l: *xev.Loop,
+                c: *xev.Completion,
+                r: xev.Result,
+            ) xev.CallbackAction {
+                _ = ud;
+                _ = l;
+                _ = c;
+                _ = r.write catch unreachable;
+                return .disarm;
+            }
+        }).callback,
+    };
+    loop.add(&c_write);
+
+    // Wait for the write
+    try loop.run(.until_done);
+
+    // Read
+    var read_buf: [128]u8 = undefined;
+    var read_len: usize = 0;
+    var c_read: xev.Completion = .{
+        .op = .{
+            .read = .{
+                .handle = f_handle,
+                .buffer = .{ .slice = &read_buf },
+            },
+        },
+        .userdata = &read_len,
+        .callback = (struct {
+            fn callback(
+                ud: ?*anyopaque,
+                l: *xev.Loop,
+                c: *xev.Completion,
+                r: xev.Result,
+            ) xev.CallbackAction {
+                _ = l;
+                _ = c;
+                const ptr = @ptrCast(*usize, @alignCast(@alignOf(usize), ud.?));
+                ptr.* = r.read catch unreachable;
+                return .disarm;
+            }
+        }).callback,
+    };
+    loop.add(&c_read);
+
+    // Wait for the read
+    try loop.run(.until_done);
+    try testing.expectEqualSlices(u8, &write_buf, read_buf[0..read_len]);
+}
+
+test "iocp: socket accept/connect/send/recv/close" {
+    const mem = std.mem;
+    const net = std.net;
+    const testing = std.testing;
+
+    var loop = try Loop.init(.{});
+    defer loop.deinit();
+
+    // Create a TCP server socket
+    const address = try net.Address.parseIp4("127.0.0.1", 3131);
+    const kernel_backlog = 1;
+    var ln = try windows.WSASocketW(std.os.AF.INET, std.os.SOCK.STREAM, std.os.IPPROTO.TCP, null, 0, windows.ws2_32.WSA_FLAG_OVERLAPPED);
+    errdefer std.os.closeSocket(ln);
+
+    try std.os.setsockopt(ln, std.os.SOL.SOCKET, std.os.SO.REUSEADDR, &mem.toBytes(@as(c_int, 1)));
+    try std.os.bind(ln, &address.any, address.getOsSockLen());
+    try std.os.listen(ln, kernel_backlog);
+
+    // Create a TCP client socket
+    var client_conn = try windows.WSASocketW(std.os.AF.INET, std.os.SOCK.STREAM, std.os.IPPROTO.TCP, null, 0, windows.ws2_32.WSA_FLAG_OVERLAPPED);
+    errdefer std.os.closeSocket(client_conn);
+
+    // Accept
+    var server_conn = try windows.WSASocketW(std.os.AF.INET, std.os.SOCK.STREAM, std.os.IPPROTO.TCP, null, 0, windows.ws2_32.WSA_FLAG_OVERLAPPED);
+
+    try loop.associate_handle(@ptrCast(windows.HANDLE, ln));
+    try loop.associate_handle(@ptrCast(windows.HANDLE, client_conn));
+    try loop.associate_handle(@ptrCast(windows.HANDLE, server_conn));
+
+    var server_conn_result: Result = undefined;
+    var c_accept: Completion = .{
+        .op = .{
+            .accept = .{
+                .listen_socket = ln,
+                .accept_socket = server_conn,
+            },
+        },
+
+        .userdata = &server_conn_result,
+        .callback = (struct {
+            fn callback(
+                ud: ?*anyopaque,
+                l: *xev.Loop,
+                c: *xev.Completion,
+                r: xev.Result,
+            ) xev.CallbackAction {
+                _ = l;
+                _ = c;
+                const conn = @ptrCast(*Result, @alignCast(@alignOf(Result), ud.?));
+                conn.* = r;
+                return .disarm;
+            }
+        }).callback,
+    };
+    loop.add(&c_accept);
+
+    // Connect
+    var connected = false;
+    var c_connect: xev.Completion = .{
+        .op = .{
+            .connect = .{
+                .socket = client_conn,
+                .addr = address,
+            },
+        },
+
+        .userdata = &connected,
+        .callback = (struct {
+            fn callback(
+                ud: ?*anyopaque,
+                l: *xev.Loop,
+                c: *xev.Completion,
+                r: xev.Result,
+            ) xev.CallbackAction {
+                _ = l;
+                _ = c;
+                _ = r.connect catch unreachable;
+                const b = @ptrCast(*bool, ud.?);
+                b.* = true;
+                return .disarm;
+            }
+        }).callback,
+    };
+    loop.add(&c_connect);
+
+    // Wait for the connection to be established
+    try loop.run(.until_done);
+    //try testing.expect(server_conn > 0);
+    try testing.expect(connected);
+
+    // Send
+    var c_send: xev.Completion = .{
+        .op = .{
+            .send = .{
+                .socket = client_conn,
+                .buffer = .{ .slice = &[_]u8{ 1, 1, 2, 3, 5, 8, 13 } },
+            },
+        },
+
+        .callback = (struct {
+            fn callback(
+                ud: ?*anyopaque,
+                l: *xev.Loop,
+                c: *xev.Completion,
+                r: xev.Result,
+            ) xev.CallbackAction {
+                _ = l;
+                _ = c;
+                _ = r.send catch unreachable;
+                _ = ud;
+                return .disarm;
+            }
+        }).callback,
+    };
+    loop.add(&c_send);
+
+    // Receive
+    var recv_buf: [128]u8 = undefined;
+    var recv_len: usize = 0;
+    var c_recv: xev.Completion = .{
+        .op = .{
+            .recv = .{
+                .socket = server_conn,
+                .buffer = .{ .slice = &recv_buf },
+            },
+        },
+
+        .userdata = &recv_len,
+        .callback = (struct {
+            fn callback(
+                ud: ?*anyopaque,
+                l: *xev.Loop,
+                c: *xev.Completion,
+                r: xev.Result,
+            ) xev.CallbackAction {
+                _ = l;
+                _ = c;
+                const ptr = @ptrCast(*usize, @alignCast(@alignOf(usize), ud.?));
+                ptr.* = r.recv catch unreachable;
+                return .disarm;
+            }
+        }).callback,
+    };
+    loop.add(&c_recv);
+
+    // Wait for the send/receive
+    try loop.run(.until_done);
+    try testing.expectEqualSlices(u8, c_send.op.send.buffer.slice, recv_buf[0..recv_len]);
+
+    // Shutdown
+    var shutdown = false;
+    var c_client_shutdown: xev.Completion = .{
+        .op = .{
+            .shutdown = .{
+                .socket = client_conn,
+            },
+        },
+
+        .userdata = &shutdown,
+        .callback = (struct {
+            fn callback(
+                ud: ?*anyopaque,
+                l: *xev.Loop,
+                c: *xev.Completion,
+                r: xev.Result,
+            ) xev.CallbackAction {
+                _ = l;
+                _ = c;
+                _ = r.shutdown catch unreachable;
+                const ptr = @ptrCast(*bool, @alignCast(@alignOf(bool), ud.?));
+                ptr.* = true;
+                return .disarm;
+            }
+        }).callback,
+    };
+    loop.add(&c_client_shutdown);
+    try loop.run(.until_done);
+    try testing.expect(shutdown);
+
+    // Read should be EOF
+    var eof: ?bool = null;
+    c_recv = .{
+        .op = .{
+            .recv = .{
+                .socket = server_conn,
+                .buffer = .{ .slice = &recv_buf },
+            },
+        },
+
+        .userdata = &eof,
+        .callback = (struct {
+            fn callback(
+                ud: ?*anyopaque,
+                l: *xev.Loop,
+                c: *xev.Completion,
+                r: xev.Result,
+            ) xev.CallbackAction {
+                _ = l;
+                _ = c;
+                const ptr = @ptrCast(*?bool, @alignCast(@alignOf(?bool), ud.?));
+                ptr.* = if (r.recv) |_| false else |err| switch (err) {
+                    error.EOF => true,
+                    else => false,
+                };
+                return .disarm;
+            }
+        }).callback,
+    };
+    loop.add(&c_recv);
+
+    try loop.run(.until_done);
+    try testing.expect(eof.? == true);
+
+    // Close
+    var client_conn_closed: bool = false;
+    var c_client_close: xev.Completion = .{
+        .op = .{
+            .close = .{
+                .socket = client_conn,
+            },
+        },
+
+        .userdata = &client_conn_closed,
+        .callback = (struct {
+            fn callback(
+                ud: ?*anyopaque,
+                l: *xev.Loop,
+                c: *xev.Completion,
+                r: xev.Result,
+            ) xev.CallbackAction {
+                _ = l;
+                _ = c;
+                _ = r.close catch unreachable;
+                const ptr = @ptrCast(*bool, @alignCast(@alignOf(bool), ud.?));
+                ptr.* = true;
+                return .disarm;
+            }
+        }).callback,
+    };
+    loop.add(&c_client_close);
+
+    var ln_closed: bool = false;
+    var c_server_close: xev.Completion = .{
+        .op = .{
+            .close = .{
+                .socket = ln,
+            },
+        },
+
+        .userdata = &ln_closed,
+        .callback = (struct {
+            fn callback(
+                ud: ?*anyopaque,
+                l: *xev.Loop,
+                c: *xev.Completion,
+                r: xev.Result,
+            ) xev.CallbackAction {
+                _ = l;
+                _ = c;
+                _ = r.close catch unreachable;
+                const ptr = @ptrCast(*bool, @alignCast(@alignOf(bool), ud.?));
+                ptr.* = true;
+                return .disarm;
+            }
+        }).callback,
+    };
+    loop.add(&c_server_close);
+
+    // Wait for the sockets to close
+    try loop.run(.until_done);
+    try testing.expect(ln_closed);
+    try testing.expect(client_conn_closed);
+}
+
+test "iocp: recv cancellation" {
+    const mem = std.mem;
+    const net = std.net;
+    const testing = std.testing;
+
+    var loop = try Loop.init(.{});
+    defer loop.deinit();
+
+    // Create a TCP server socket
+    const address = try net.Address.parseIp4("127.0.0.1", 3131);
+    var socket = try windows.WSASocketW(std.os.AF.INET, std.os.SOCK.DGRAM, std.os.IPPROTO.UDP, null, 0, windows.ws2_32.WSA_FLAG_OVERLAPPED);
+    errdefer std.os.closeSocket(socket);
+
+    try std.os.setsockopt(socket, std.os.SOL.SOCKET, std.os.SO.REUSEADDR, &mem.toBytes(@as(c_int, 1)));
+    try std.os.bind(socket, &address.any, address.getOsSockLen());
+
+    try loop.associate_handle(@ptrCast(windows.HANDLE, socket));
+
+    var recv_buf: [128]u8 = undefined;
+    var recv_result: Result = undefined;
+    var c_recv: xev.Completion = .{
+        .op = .{
+            .recv = .{
+                .socket = socket,
+                .buffer = .{ .slice = &recv_buf },
+            },
+        },
+
+        .userdata = &recv_result,
+        .callback = (struct {
+            fn callback(
+                ud: ?*anyopaque,
+                l: *xev.Loop,
+                c: *xev.Completion,
+                r: xev.Result,
+            ) xev.CallbackAction {
+                _ = l;
+                _ = c;
+                const ptr = @ptrCast(*Result, @alignCast(@alignOf(Result), ud.?));
+                ptr.* = r;
+                return .disarm;
+            }
+        }).callback,
+    };
+    loop.add(&c_recv);
+
+    try loop.submit();
+
+    var c_cancel_recv: xev.Completion = .{
+        .op = .{ .cancel = .{ .c = &c_recv } },
+        .callback = (struct {
+            fn callback(
+                ud: ?*anyopaque,
+                l: *xev.Loop,
+                c: *xev.Completion,
+                r: xev.Result,
+            ) xev.CallbackAction {
+                _ = r.cancel catch unreachable;
+                _ = ud;
+                _ = l;
+                _ = c;
+                return .disarm;
+            }
+        }).callback,
+    };
+    loop.add(&c_cancel_recv);
+
+    // Wait for the send/receive
+    try loop.run(.until_done);
+
+    try testing.expect(recv_result == .recv);
+    try testing.expectError(error.Canceled, recv_result.recv);
+}
+
+test "iocp: accept cancellation" {
+    const mem = std.mem;
+    const net = std.net;
+    const testing = std.testing;
+
+    var loop = try Loop.init(.{});
+    defer loop.deinit();
+
+    // Create a TCP server socket
+    const address = try net.Address.parseIp4("127.0.0.1", 3131);
+    const kernel_backlog = 1;
+    var ln = try windows.WSASocketW(std.os.AF.INET, std.os.SOCK.STREAM, std.os.IPPROTO.TCP, null, 0, windows.ws2_32.WSA_FLAG_OVERLAPPED);
+    errdefer std.os.closeSocket(ln);
+
+    try std.os.setsockopt(ln, std.os.SOL.SOCKET, std.os.SO.REUSEADDR, &mem.toBytes(@as(c_int, 1)));
+    try std.os.bind(ln, &address.any, address.getOsSockLen());
+    try std.os.listen(ln, kernel_backlog);
+
+    // Accept
+    var server_conn = try windows.WSASocketW(std.os.AF.INET, std.os.SOCK.STREAM, std.os.IPPROTO.TCP, null, 0, windows.ws2_32.WSA_FLAG_OVERLAPPED);
+
+    try loop.associate_handle(@ptrCast(windows.HANDLE, ln));
+    try loop.associate_handle(@ptrCast(windows.HANDLE, server_conn));
+
+    var server_conn_result: Result = undefined;
+    var c_accept: Completion = .{
+        .op = .{
+            .accept = .{
+                .listen_socket = ln,
+                .accept_socket = server_conn,
+            },
+        },
+
+        .userdata = &server_conn_result,
+        .callback = (struct {
+            fn callback(
+                ud: ?*anyopaque,
+                l: *xev.Loop,
+                c: *xev.Completion,
+                r: xev.Result,
+            ) xev.CallbackAction {
+                _ = l;
+                _ = c;
+                const conn = @ptrCast(*Result, @alignCast(@alignOf(Result), ud.?));
+                conn.* = r;
+                return .disarm;
+            }
+        }).callback,
+    };
+    loop.add(&c_accept);
+
+    try loop.submit();
+
+    var c_cancel_accept: xev.Completion = .{
+        .op = .{ .cancel = .{ .c = &c_accept } },
+        .callback = (struct {
+            fn callback(
+                ud: ?*anyopaque,
+                l: *xev.Loop,
+                c: *xev.Completion,
+                r: xev.Result,
+            ) xev.CallbackAction {
+                _ = r.cancel catch unreachable;
+                _ = ud;
+                _ = l;
+                _ = c;
+                return .disarm;
+            }
+        }).callback,
+    };
+    loop.add(&c_cancel_accept);
+
+    // Wait for the send/receive
+    try loop.run(.until_done);
+
+    try testing.expect(server_conn_result == .accept);
+    try testing.expectError(error.Canceled, server_conn_result.accept);
+}

--- a/src/bench/ping-pongs.zig
+++ b/src/bench/ping-pongs.zig
@@ -179,7 +179,7 @@ const Client = struct {
         socket: xev.TCP,
         r: xev.TCP.ShutdownError!void,
     ) xev.CallbackAction {
-        _ = r catch unreachable;
+        _ = r catch {};
 
         const self = self_.?;
         socket.close(l, c, Client, self, closeCallback);
@@ -231,7 +231,7 @@ const Server = struct {
     /// Must be called with stable self pointer.
     pub fn start(self: *Server) !void {
         const addr = try std.net.Address.parseIp4("127.0.0.1", 3131);
-        const socket = try xev.TCP.init(addr);
+        var socket = try xev.TCP.init(addr);
 
         const c = try self.completion_pool.create();
         try socket.bind(addr);
@@ -333,7 +333,7 @@ const Server = struct {
         s: xev.TCP,
         r: xev.TCP.ShutdownError!void,
     ) xev.CallbackAction {
-        _ = r catch unreachable;
+        _ = r catch {};
 
         const self = self_.?;
         s.close(l, c, Server, self, closeCallback);

--- a/src/bench/udp_pummel_1v1.zig
+++ b/src/bench/udp_pummel_1v1.zig
@@ -35,7 +35,7 @@ pub fn run(comptime n_senders: comptime_int, comptime n_receivers: comptime_int)
 
     var receivers: [n_receivers]Receiver = undefined;
     for (&receivers, 0..) |*r, i| {
-        const addr = try std.net.Address.parseIp4("0.0.0.0", @as(u16, @intCast(base_port + i)));
+        const addr = try std.net.Address.parseIp4("127.0.0.1", @as(u16, @intCast(base_port + i)));
         r.* = .{ .udp = try xev.UDP.init(addr) };
         try r.udp.bind(addr);
         r.udp.read(
@@ -52,7 +52,7 @@ pub fn run(comptime n_senders: comptime_int, comptime n_receivers: comptime_int)
     var senders: [n_senders]Sender = undefined;
     for (&senders, 0..) |*s, i| {
         const addr = try std.net.Address.parseIp4(
-            "0.0.0.0",
+            "127.0.0.1",
             @as(u16, @intCast(base_port + (i % n_receivers))),
         );
         s.* = .{ .udp = try xev.UDP.init(addr) };

--- a/src/debug.zig
+++ b/src/debug.zig
@@ -1,0 +1,58 @@
+const std = @import("std");
+
+inline fn indent(depth: usize, writer: anytype) !void {
+    for (0..depth) |_| try writer.writeByte(' ');
+}
+
+pub fn describe(comptime T: type, writer: anytype, depth: usize) !void {
+    const type_info = @typeInfo(T);
+    switch (type_info) {
+        .Type,
+        .Void,
+        .Bool,
+        .NoReturn,
+        .Int,
+        .Float,
+        .Pointer,
+        .Array,
+        .ComptimeFloat,
+        .ComptimeInt,
+        .Undefined,
+        .Null,
+        .Optional,
+        .ErrorUnion,
+        .ErrorSet,
+        .Enum,
+        .Fn,
+        .Opaque,
+        .Frame,
+        .AnyFrame,
+        .Vector,
+        .EnumLiteral,
+        => {
+            try writer.print("{s} ({d} bytes)", .{ @typeName(T), @sizeOf(T) });
+        },
+        .Union => |s| {
+            try writer.print("{s} ({d} bytes) {{\n", .{ @typeName(T), @sizeOf(T) });
+            inline for (s.fields) |f| {
+                try indent(depth + 4, writer);
+                try writer.print("{s}: ", .{f.name});
+                try describe(f.type, writer, depth + 4);
+                try writer.writeByte('\n');
+            }
+            try indent(depth, writer);
+            try writer.writeByte('}');
+        },
+        .Struct => |s| {
+            try writer.print("{s} ({d} bytes) {{\n", .{ @typeName(T), @sizeOf(T) });
+            inline for (s.fields) |f| {
+                try indent(depth + 4, writer);
+                try writer.print("{s}: ", .{f.name});
+                try describe(f.type, writer, depth + 4);
+                try writer.writeByte('\n');
+            }
+            try indent(depth, writer);
+            try writer.writeByte('}');
+        },
+    }
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -88,25 +88,25 @@ pub fn Xev(comptime be: Backend, comptime T: type) type {
         pub const RunMode = loop.RunMode;
         pub const CallbackAction = loop.CallbackAction;
         pub const CompletionState = loop.CompletionState;
-        //
-        // // Error types
-        //pub const AcceptError = T.AcceptError;
-        //pub const CancelError = T.CancelError;
-        //pub const CloseError = T.CloseError;
-        //pub const ConnectError = T.ConnectError;
-        //pub const ShutdownError = T.ShutdownError;
-        //pub const WriteError = T.WriteError;
-        //pub const ReadError = T.ReadError;
+
+        /// Error types
+        pub const AcceptError = T.AcceptError;
+        pub const CancelError = T.CancelError;
+        pub const CloseError = T.CloseError;
+        pub const ConnectError = T.ConnectError;
+        pub const ShutdownError = T.ShutdownError;
+        pub const WriteError = T.WriteError;
+        pub const ReadError = T.ReadError;
 
         /// The high-level helper interfaces that make it easier to perform
         /// common tasks. These may not work with all possible Loop implementations.
-        //pub const Async = @import("watcher/async.zig").Async(Self);
-        //pub const File = @import("watcher/file.zig").File(Self);
+        pub const Async = @import("watcher/async.zig").Async(Self);
+        pub const File = @import("watcher/file.zig").File(Self);
         //pub const Process = @import("watcher/process.zig").Process(Self);
-        //pub const Stream = stream.GenericStream(Self);
-        //pub const Timer = @import("watcher/timer.zig").Timer(Self);
-        //pub const TCP = @import("watcher/tcp.zig").TCP(Self);
-        //pub const UDP = @import("watcher/udp.zig").UDP(Self);
+        pub const Stream = stream.GenericStream(Self);
+        pub const Timer = @import("watcher/timer.zig").Timer(Self);
+        pub const TCP = @import("watcher/tcp.zig").TCP(Self);
+        pub const UDP = @import("watcher/udp.zig").UDP(Self);
 
         /// The callback of the main Loop operations. Higher level interfaces may
         /// use a different callback mechanism.
@@ -150,7 +150,7 @@ test {
     _ = ThreadPool;
 
     // Test the C API
-    //if (builtin.os.tag != .wasi) _ = @import("c_api.zig");
+    if (builtin.os.tag != .wasi) _ = @import("c_api.zig");
 
     // OS-specific tests
     switch (builtin.os.tag) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -15,6 +15,7 @@ pub const IO_Uring = Xev(.io_uring, @import("backend/io_uring.zig"));
 pub const Epoll = Xev(.epoll, @import("backend/epoll.zig"));
 pub const Kqueue = Xev(.kqueue, @import("backend/kqueue.zig"));
 pub const WasiPoll = Xev(.wasi_poll, @import("backend/wasi_poll.zig"));
+pub const IOCP = Xev(.iocp, @import("backend/iocp.zig"));
 
 /// Generic thread pool implementation.
 pub const ThreadPool = @import("ThreadPool.zig");
@@ -30,6 +31,7 @@ pub const Backend = enum {
     epoll,
     kqueue,
     wasi_poll,
+    iocp,
 
     /// Returns a recommend default backend from inspecting the system.
     pub fn default() Backend {
@@ -37,6 +39,7 @@ pub const Backend = enum {
             .linux => .io_uring,
             .macos => .kqueue,
             .wasi => .wasi_poll,
+            .windows => .iocp,
             else => null,
         }) orelse {
             @compileLog(builtin.os);
@@ -51,6 +54,7 @@ pub const Backend = enum {
             .epoll => Epoll,
             .kqueue => Kqueue,
             .wasi_poll => WasiPoll,
+            .iocp => IOCP,
         };
     }
 };
@@ -86,23 +90,23 @@ pub fn Xev(comptime be: Backend, comptime T: type) type {
         pub const CompletionState = loop.CompletionState;
         //
         // // Error types
-        pub const AcceptError = T.AcceptError;
-        pub const CancelError = T.CancelError;
-        pub const CloseError = T.CloseError;
-        pub const ConnectError = T.ConnectError;
-        pub const ShutdownError = T.ShutdownError;
-        pub const WriteError = T.WriteError;
-        pub const ReadError = T.ReadError;
+        //pub const AcceptError = T.AcceptError;
+        //pub const CancelError = T.CancelError;
+        //pub const CloseError = T.CloseError;
+        //pub const ConnectError = T.ConnectError;
+        //pub const ShutdownError = T.ShutdownError;
+        //pub const WriteError = T.WriteError;
+        //pub const ReadError = T.ReadError;
 
         /// The high-level helper interfaces that make it easier to perform
         /// common tasks. These may not work with all possible Loop implementations.
-        pub const Async = @import("watcher/async.zig").Async(Self);
-        pub const File = @import("watcher/file.zig").File(Self);
-        pub const Process = @import("watcher/process.zig").Process(Self);
-        pub const Stream = stream.GenericStream(Self);
-        pub const Timer = @import("watcher/timer.zig").Timer(Self);
-        pub const TCP = @import("watcher/tcp.zig").TCP(Self);
-        pub const UDP = @import("watcher/udp.zig").UDP(Self);
+        //pub const Async = @import("watcher/async.zig").Async(Self);
+        //pub const File = @import("watcher/file.zig").File(Self);
+        //pub const Process = @import("watcher/process.zig").Process(Self);
+        //pub const Stream = stream.GenericStream(Self);
+        //pub const Timer = @import("watcher/timer.zig").Timer(Self);
+        //pub const TCP = @import("watcher/tcp.zig").TCP(Self);
+        //pub const UDP = @import("watcher/udp.zig").UDP(Self);
 
         /// The callback of the main Loop operations. Higher level interfaces may
         /// use a different callback mechanism.
@@ -146,7 +150,7 @@ test {
     _ = ThreadPool;
 
     // Test the C API
-    if (builtin.os.tag != .wasi) _ = @import("c_api.zig");
+    //if (builtin.os.tag != .wasi) _ = @import("c_api.zig");
 
     // OS-specific tests
     switch (builtin.os.tag) {
@@ -159,6 +163,10 @@ test {
         .wasi => {
             //_ = WasiPoll;
             _ = @import("backend/wasi_poll.zig");
+        },
+
+        .windows => {
+            _ = @import("backend/iocp.zig");
         },
 
         else => {},

--- a/src/watcher/async.zig
+++ b/src/watcher/async.zig
@@ -434,7 +434,7 @@ fn AsyncIOCP(comptime xev: type) type {
                         r: xev.Result,
                     ) xev.CallbackAction {
                         return @call(.always_inline, cb, .{
-                            @ptrCast(?*Userdata, @alignCast(@max(1, @alignOf(Userdata)), ud)),
+                            common.userdataValue(Userdata, ud),
                             l_inner,
                             c_inner,
                             if (r.async_wait) |_| {} else |err| err,

--- a/src/watcher/async.zig
+++ b/src/watcher/async.zig
@@ -17,6 +17,7 @@ pub fn Async(comptime xev: type) type {
 
         // Supported, uses mach ports
         .kqueue => AsyncMachPort(xev),
+        .iocp => AsyncIOCP(xev),
     };
 }
 
@@ -383,6 +384,46 @@ fn AsyncLoopState(comptime xev: type, comptime threaded: bool) type {
 
         /// Common tests
         pub usingnamespace AsyncTests(xev, Self);
+    };
+}
+
+fn AsyncIOCP(comptime xev: type) type {
+    return struct {
+        const Self = @This();
+
+        pub const WaitError = xev.Sys.AsyncError;
+
+        pub fn init() !Self {
+            return error.NotImplemented;
+        }
+
+        pub fn deinit(self: *Self) void {
+            _ = self;
+        }
+
+        pub fn wait(
+            self: *Self,
+            loop: *xev.Loop,
+            c: *xev.Completion,
+            comptime Userdata: type,
+            userdata: ?*Userdata,
+            comptime cb: *const fn (
+                ud: ?*Userdata,
+                l: *xev.Loop,
+                c: *xev.Completion,
+                r: WaitError!void,
+            ) xev.CallbackAction,
+        ) void {
+            _ = cb;
+            _ = userdata;
+            _ = c;
+            _ = loop;
+            _ = self;
+        }
+
+        pub fn notify(self: *Self) !void {
+            _ = self;
+        }
     };
 }
 

--- a/src/watcher/file.zig
+++ b/src/watcher/file.zig
@@ -27,6 +27,7 @@ const stream = @import("stream.zig");
 pub fn File(comptime xev: type) type {
     return struct {
         const Self = @This();
+        const FdType = if (xev.backend == .iocp) os.windows.HANDLE else os.socket_t;
 
         /// The underlying file
         fd: std.os.fd_t,
@@ -290,6 +291,8 @@ pub fn File(comptime xev: type) type {
         test "read/write" {
             // wasi: local files don't work with poll (always ready)
             if (builtin.os.tag == .wasi) return error.SkipZigTest;
+            // windows: std.fs.File is not opened with OVERLAPPED flag.
+            if (builtin.os.tag == .windows) return error.SkipZigTest;
 
             const testing = std.testing;
 
@@ -432,6 +435,8 @@ pub fn File(comptime xev: type) type {
         test "queued writes" {
             // wasi: local files don't work with poll (always ready)
             if (builtin.os.tag == .wasi) return error.SkipZigTest;
+            // windows: std.fs.File is not opened with OVERLAPPED flag.
+            if (builtin.os.tag == .windows) return error.SkipZigTest;
 
             const testing = std.testing;
 

--- a/src/watcher/file.zig
+++ b/src/watcher/file.zig
@@ -30,7 +30,7 @@ pub fn File(comptime xev: type) type {
         const FdType = if (xev.backend == .iocp) os.windows.HANDLE else os.socket_t;
 
         /// The underlying file
-        fd: std.os.fd_t,
+        fd: FdType,
 
         pub usingnamespace stream.Stream(xev, Self, .{
             .close = true,
@@ -111,6 +111,7 @@ pub fn File(comptime xev: type) type {
                     switch (xev.backend) {
                         .io_uring,
                         .wasi_poll,
+                        .iocp,
                         => {},
 
                         .epoll => {
@@ -274,6 +275,7 @@ pub fn File(comptime xev: type) type {
                     switch (xev.backend) {
                         .io_uring,
                         .wasi_poll,
+                        .iocp,
                         => {},
 
                         .epoll => {
@@ -365,6 +367,8 @@ pub fn File(comptime xev: type) type {
         test "pread/pwrite" {
             // wasi: local files don't work with poll (always ready)
             if (builtin.os.tag == .wasi) return error.SkipZigTest;
+            // windows: std.fs.File is not opened with OVERLAPPED flag.
+            if (builtin.os.tag == .windows) return error.SkipZigTest;
 
             const testing = std.testing;
 

--- a/src/watcher/process.zig
+++ b/src/watcher/process.zig
@@ -16,6 +16,7 @@ pub fn Process(comptime xev: type) type {
 
         // Unsupported
         .wasi_poll => struct {},
+        .iocp => struct {},
     };
 }
 

--- a/src/watcher/tcp.zig
+++ b/src/watcher/tcp.zig
@@ -15,8 +15,9 @@ const common = @import("common.zig");
 pub fn TCP(comptime xev: type) type {
     return struct {
         const Self = @This();
+        const FdType = if (xev.backend == .iocp) os.windows.HANDLE else os.socket_t;
 
-        fd: os.socket_t,
+        fd: FdType,
 
         pub usingnamespace stream.Stream(xev, Self, .{
             .close = true,
@@ -30,21 +31,26 @@ pub fn TCP(comptime xev: type) type {
         pub fn init(addr: std.net.Address) !Self {
             if (xev.backend == .wasi_poll) @compileError("unsupported in WASI");
 
-            // On io_uring we don't use non-blocking sockets because we may
-            // just get EAGAIN over and over from completions.
-            const flags = flags: {
-                var flags: u32 = os.SOCK.STREAM | os.SOCK.CLOEXEC;
-                if (xev.backend != .io_uring) flags |= os.SOCK.NONBLOCK;
-                break :flags flags;
+            const fd = if (xev.backend == .iocp)
+                try os.windows.WSASocketW(addr.any.family, os.SOCK.STREAM, 0, null, 0, os.windows.ws2_32.WSA_FLAG_OVERLAPPED)
+            else fd: {
+                // On io_uring we don't use non-blocking sockets because we may
+                // just get EAGAIN over and over from completions.
+                const flags = flags: {
+                    var flags: u32 = os.SOCK.STREAM | os.SOCK.CLOEXEC;
+                    if (xev.backend != .io_uring) flags |= os.SOCK.NONBLOCK;
+                    break :flags flags;
+                };
+                break :fd try os.socket(addr.any.family, flags, 0);
             };
 
             return .{
-                .fd = try os.socket(addr.any.family, flags, 0),
+                .fd = fd,
             };
         }
 
         /// Initialize a TCP socket from a file descriptor.
-        pub fn initFd(fd: os.socket_t) Self {
+        pub fn initFd(fd: FdType) Self {
             return .{
                 .fd = fd,
             };
@@ -54,8 +60,10 @@ pub fn TCP(comptime xev: type) type {
         pub fn bind(self: Self, addr: std.net.Address) !void {
             if (xev.backend == .wasi_poll) @compileError("unsupported in WASI");
 
-            try os.setsockopt(self.fd, os.SOL.SOCKET, os.SO.REUSEADDR, &std.mem.toBytes(@as(c_int, 1)));
-            try os.bind(self.fd, &addr.any, addr.getOsSockLen());
+            const fd = if (xev.backend == .iocp) @as(os.windows.ws2_32.SOCKET, @ptrCast(self.fd)) else self.fd;
+
+            try os.setsockopt(fd, os.SOL.SOCKET, os.SO.REUSEADDR, &std.mem.toBytes(@as(c_int, 1)));
+            try os.bind(fd, &addr.any, addr.getOsSockLen());
         }
 
         /// Listen for connections on the socket. This puts the socket into passive
@@ -63,7 +71,9 @@ pub fn TCP(comptime xev: type) type {
         pub fn listen(self: Self, backlog: u31) !void {
             if (xev.backend == .wasi_poll) @compileError("unsupported in WASI");
 
-            try os.listen(self.fd, backlog);
+            const fd = if (xev.backend == .iocp) @as(os.windows.ws2_32.SOCKET, @ptrCast(self.fd)) else self.fd;
+
+            try os.listen(fd, backlog);
         }
 
         /// Accept a single connection.
@@ -110,6 +120,7 @@ pub fn TCP(comptime xev: type) type {
                 .io_uring,
                 .kqueue,
                 .wasi_poll,
+                .iocp,
                 => {},
 
                 .epoll => c.flags.dup = true,
@@ -237,6 +248,10 @@ pub fn TCP(comptime xev: type) type {
             var sock_len = address.getOsSockLen();
             try os.getsockname(server.fd, &address.any, &sock_len);
             const client = try Self.init(address);
+
+            //const address = try std.net.Address.parseIp4("127.0.0.1", 3132);
+            //var server = try Self.init(address);
+            //var client = try Self.init(address);
 
             // Completions we need
             var c_accept: xev.Completion = undefined;

--- a/src/watcher/timer.zig
+++ b/src/watcher/timer.zig
@@ -197,6 +197,7 @@ pub fn Timer(comptime xev: type) type {
                         }
                     }).callback,
                 },
+                .iocp => unreachable,
             };
 
             loop.add(c_cancel);

--- a/src/watcher/timer.zig
+++ b/src/watcher/timer.zig
@@ -173,6 +173,7 @@ pub fn Timer(comptime xev: type) type {
                 .epoll,
                 .kqueue,
                 .wasi_poll,
+                .iocp,
                 => .{
                     .op = .{
                         .cancel = .{
@@ -197,7 +198,6 @@ pub fn Timer(comptime xev: type) type {
                         }
                     }).callback,
                 },
-                .iocp => unreachable,
             };
 
             loop.add(c_cancel);

--- a/src/watcher/udp.zig
+++ b/src/watcher/udp.zig
@@ -24,6 +24,7 @@ pub fn UDP(comptime xev: type) type {
 
         // Noop
         .wasi_poll => struct {},
+        .iocp => struct {},
     };
 }
 

--- a/src/watcher/udp.zig
+++ b/src/watcher/udp.zig
@@ -551,6 +551,7 @@ fn UDPSendMsg(comptime xev: type) type {
                 .io_uring,
                 .kqueue,
                 .wasi_poll,
+                .iocp,
                 => {},
 
                 .epoll => c.flags.dup = true,
@@ -660,6 +661,7 @@ fn UDPSendMsg(comptime xev: type) type {
                 .io_uring,
                 .kqueue,
                 .wasi_poll,
+                .iocp,
                 => {},
 
                 .epoll => c.flags.dup = true,

--- a/src/windows.zig
+++ b/src/windows.zig
@@ -33,7 +33,7 @@ pub const exp = struct {
         overlapped: ?*windows.OVERLAPPED,
     ) windows.ReadFileError!?usize {
         var read: windows.DWORD = 0;
-        const result: windows.BOOL = windows.kernel32.ReadFile(handle, buffer.ptr, @intCast(windows.DWORD, buffer.len), &read, overlapped);
+        const result: windows.BOOL = windows.kernel32.ReadFile(handle, buffer.ptr, @as(windows.DWORD, @intCast(buffer.len)), &read, overlapped);
         if (result == windows.FALSE) {
             const err = windows.kernel32.GetLastError();
             return switch (err) {
@@ -42,7 +42,7 @@ pub const exp = struct {
             };
         }
 
-        return @intCast(usize, read);
+        return @as(usize, @intCast(read));
     }
 
     pub fn WriteFile(
@@ -51,7 +51,7 @@ pub const exp = struct {
         overlapped: ?*windows.OVERLAPPED,
     ) windows.WriteFileError!?usize {
         var written: windows.DWORD = 0;
-        const result: windows.BOOL = windows.kernel32.WriteFile(handle, buffer.ptr, @intCast(windows.DWORD, buffer.len), &written, overlapped);
+        const result: windows.BOOL = windows.kernel32.WriteFile(handle, buffer.ptr, @as(windows.DWORD, @intCast(buffer.len)), &written, overlapped);
         if (result == windows.FALSE) {
             const err = windows.kernel32.GetLastError();
             return switch (err) {
@@ -60,7 +60,7 @@ pub const exp = struct {
             };
         }
 
-        return @intCast(usize, written);
+        return @as(usize, @intCast(written));
     }
 
     pub const DeleteFileError = error{} || std.os.UnexpectedError;

--- a/src/windows.zig
+++ b/src/windows.zig
@@ -1,88 +1,77 @@
 const std = @import("std");
 const windows = std.os.windows;
-const kernel32 = windows.kernel32;
 
 pub usingnamespace std.os.windows;
 
-pub const FILE_GENERIC_READ =
-    windows.STANDARD_RIGHTS_READ |
-    windows.FILE_READ_DATA |
-    windows.FILE_READ_ATTRIBUTES |
-    windows.FILE_READ_EA |
-    windows.SYNCHRONIZE;
-pub const FILE_GENERIC_WRITE =
-    windows.STANDARD_RIGHTS_WRITE |
-    windows.FILE_WRITE_DATA |
-    windows.FILE_WRITE_ATTRIBUTES |
-    windows.FILE_WRITE_EA |
-    windows.SYNCHRONIZE;
+/// Namespace containing missing utils from std
+pub const exp = struct {
+    pub const CreateFileError = error{} || std.os.UnexpectedError;
 
-pub const CreateFileError = error{} || std.os.UnexpectedError;
+    pub fn CreateFile(
+        lpFileName: [*:0]const u16,
+        dwDesiredAccess: windows.DWORD,
+        dwShareMode: windows.DWORD,
+        lpSecurityAttributes: ?*windows.SECURITY_ATTRIBUTES,
+        dwCreationDisposition: windows.DWORD,
+        dwFlagsAndAttributes: windows.DWORD,
+        hTemplateFile: ?windows.HANDLE,
+    ) CreateFileError!windows.HANDLE {
+        const handle = windows.kernel32.CreateFileW(lpFileName, dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
+        if (handle == windows.INVALID_HANDLE_VALUE) {
+            const err = windows.kernel32.GetLastError();
+            return switch (err) {
+                else => windows.unexpectedError(err),
+            };
+        }
 
-pub fn CreateFile(
-    lpFileName: [*:0]const u16,
-    dwDesiredAccess: windows.DWORD,
-    dwShareMode: windows.DWORD,
-    lpSecurityAttributes: ?*windows.SECURITY_ATTRIBUTES,
-    dwCreationDisposition: windows.DWORD,
-    dwFlagsAndAttributes: windows.DWORD,
-    hTemplateFile: ?windows.HANDLE,
-) CreateFileError!windows.HANDLE {
-    const handle = windows.kernel32.CreateFileW(lpFileName, dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
-    if (handle == windows.INVALID_HANDLE_VALUE) {
-        const err = windows.kernel32.GetLastError();
-        return switch (err) {
-            else => windows.unexpectedError(err),
-        };
+        return handle;
     }
 
-    return handle;
-}
+    pub fn ReadFile(
+        handle: windows.HANDLE,
+        buffer: []u8,
+        overlapped: ?*windows.OVERLAPPED,
+    ) windows.ReadFileError!?usize {
+        var read: windows.DWORD = 0;
+        const result: windows.BOOL = windows.kernel32.ReadFile(handle, buffer.ptr, @intCast(windows.DWORD, buffer.len), &read, overlapped);
+        if (result == windows.FALSE) {
+            const err = windows.kernel32.GetLastError();
+            return switch (err) {
+                windows.Win32Error.IO_PENDING => null,
+                else => windows.unexpectedError(err),
+            };
+        }
 
-pub fn ReadFileW(
-    handle: windows.HANDLE,
-    buffer: []u8,
-    overlapped: ?*windows.OVERLAPPED,
-) windows.ReadFileError!?usize {
-    var read: windows.DWORD = 0;
-    const result: windows.BOOL = kernel32.ReadFile(handle, buffer.ptr, @intCast(windows.DWORD, buffer.len), &read, overlapped);
-    if (result == windows.FALSE) {
-        const err = kernel32.GetLastError();
-        return switch (err) {
-            windows.Win32Error.IO_PENDING => null,
-            else => windows.unexpectedError(err),
-        };
+        return @intCast(usize, read);
     }
 
-    return @intCast(usize, read);
-}
+    pub fn WriteFile(
+        handle: windows.HANDLE,
+        buffer: []const u8,
+        overlapped: ?*windows.OVERLAPPED,
+    ) windows.WriteFileError!?usize {
+        var written: windows.DWORD = 0;
+        const result: windows.BOOL = windows.kernel32.WriteFile(handle, buffer.ptr, @intCast(windows.DWORD, buffer.len), &written, overlapped);
+        if (result == windows.FALSE) {
+            const err = windows.kernel32.GetLastError();
+            return switch (err) {
+                windows.Win32Error.IO_PENDING => null,
+                else => windows.unexpectedError(err),
+            };
+        }
 
-pub fn WriteFileW(
-    handle: windows.HANDLE,
-    buffer: []const u8,
-    overlapped: ?*windows.OVERLAPPED,
-) windows.WriteFileError!?usize {
-    var written: windows.DWORD = 0;
-    const result: windows.BOOL = kernel32.WriteFile(handle, buffer.ptr, @intCast(windows.DWORD, buffer.len), &written, overlapped);
-    if (result == windows.FALSE) {
-        const err = kernel32.GetLastError();
-        return switch (err) {
-            windows.Win32Error.IO_PENDING => null,
-            else => windows.unexpectedError(err),
-        };
+        return @intCast(usize, written);
     }
 
-    return @intCast(usize, written);
-}
+    pub const DeleteFileError = error{} || std.os.UnexpectedError;
 
-pub const DeleteFileError = error{} || std.os.UnexpectedError;
-
-pub fn DeleteFileW(name: [*:0]const u16) DeleteFileError!void {
-    const result: windows.BOOL = kernel32.DeleteFileW(name);
-    if (result == windows.FALSE) {
-        const err = kernel32.GetLastError();
-        return switch (err) {
-            else => windows.unexpectedError(err),
-        };
+    pub fn DeleteFile(name: [*:0]const u16) DeleteFileError!void {
+        const result: windows.BOOL = windows.kernel32.DeleteFileW(name);
+        if (result == windows.FALSE) {
+            const err = windows.kernel32.GetLastError();
+            return switch (err) {
+                else => windows.unexpectedError(err),
+            };
+        }
     }
-}
+};

--- a/src/windows.zig
+++ b/src/windows.zig
@@ -1,0 +1,88 @@
+const std = @import("std");
+const windows = std.os.windows;
+const kernel32 = windows.kernel32;
+
+pub usingnamespace std.os.windows;
+
+pub const FILE_GENERIC_READ =
+    windows.STANDARD_RIGHTS_READ |
+    windows.FILE_READ_DATA |
+    windows.FILE_READ_ATTRIBUTES |
+    windows.FILE_READ_EA |
+    windows.SYNCHRONIZE;
+pub const FILE_GENERIC_WRITE =
+    windows.STANDARD_RIGHTS_WRITE |
+    windows.FILE_WRITE_DATA |
+    windows.FILE_WRITE_ATTRIBUTES |
+    windows.FILE_WRITE_EA |
+    windows.SYNCHRONIZE;
+
+pub const CreateFileError = error{} || std.os.UnexpectedError;
+
+pub fn CreateFile(
+    lpFileName: [*:0]const u16,
+    dwDesiredAccess: windows.DWORD,
+    dwShareMode: windows.DWORD,
+    lpSecurityAttributes: ?*windows.SECURITY_ATTRIBUTES,
+    dwCreationDisposition: windows.DWORD,
+    dwFlagsAndAttributes: windows.DWORD,
+    hTemplateFile: ?windows.HANDLE,
+) CreateFileError!windows.HANDLE {
+    const handle = windows.kernel32.CreateFileW(lpFileName, dwDesiredAccess, dwShareMode, lpSecurityAttributes, dwCreationDisposition, dwFlagsAndAttributes, hTemplateFile);
+    if (handle == windows.INVALID_HANDLE_VALUE) {
+        const err = windows.kernel32.GetLastError();
+        return switch (err) {
+            else => windows.unexpectedError(err),
+        };
+    }
+
+    return handle;
+}
+
+pub fn ReadFileW(
+    handle: windows.HANDLE,
+    buffer: []u8,
+    overlapped: ?*windows.OVERLAPPED,
+) windows.ReadFileError!?usize {
+    var read: windows.DWORD = 0;
+    const result: windows.BOOL = kernel32.ReadFile(handle, buffer.ptr, @intCast(windows.DWORD, buffer.len), &read, overlapped);
+    if (result == windows.FALSE) {
+        const err = kernel32.GetLastError();
+        return switch (err) {
+            windows.Win32Error.IO_PENDING => null,
+            else => windows.unexpectedError(err),
+        };
+    }
+
+    return @intCast(usize, read);
+}
+
+pub fn WriteFileW(
+    handle: windows.HANDLE,
+    buffer: []const u8,
+    overlapped: ?*windows.OVERLAPPED,
+) windows.WriteFileError!?usize {
+    var written: windows.DWORD = 0;
+    const result: windows.BOOL = kernel32.WriteFile(handle, buffer.ptr, @intCast(windows.DWORD, buffer.len), &written, overlapped);
+    if (result == windows.FALSE) {
+        const err = kernel32.GetLastError();
+        return switch (err) {
+            windows.Win32Error.IO_PENDING => null,
+            else => windows.unexpectedError(err),
+        };
+    }
+
+    return @intCast(usize, written);
+}
+
+pub const DeleteFileError = error{} || std.os.UnexpectedError;
+
+pub fn DeleteFileW(name: [*:0]const u16) DeleteFileError!void {
+    const result: windows.BOOL = kernel32.DeleteFileW(name);
+    if (result == windows.FALSE) {
+        const err = kernel32.GetLastError();
+        return switch (err) {
+            else => windows.unexpectedError(err),
+        };
+    }
+}


### PR DESCRIPTION
# Description
This PR brings support for Windows using the [I/O Completion Port](https://learn.microsoft.com/en-us/windows/win32/fileio/i-o-completion-ports).

Closes #10 

# Notes for reviewers
Unfortunately, this is a pretty beefy PR. I tried to clean the git history so that it's kind of reviewable commit by commit though.

My approach was similar to what @mitchellh suggested me: first the backend core, then the watchers building on top of it.

I also added support for Windows tests in GH Actions as he told me he didn't have access to a Windows machine.

Please note that this work is far from perfect, it was my first time playing with IOCP so expect some weirdness/mistakes.

## Known pain-points/limitations
**Timers**
Timings rely on `GetQueuedCompletionStatusEx` timeout parameter. I read multiple times that timings on Windows were, well, slightly inaccurate (plot twist: that's a euphemism). I'm not confident enough to deep dive into this rabbit hole, so if somebody has more knowledge on that, feel free to improve my implementation.

**Async**
I have the feeling that there is a better way to implement the `Async` watchers compared to what I did. I couldn't come up with a better way than inspiring myself from the `WASI` backend.

The part I struggled the most with was the fact that `Async` can be notified before being linked to a `Loop`. This requires to store the fact that it's notified inside the `Async` struct, but then it opens up a lot of other questions and failed to find a satisfying solution taking care of all of them.

I'll try to come back to it with a fresh mind but I'm open to suggestions in the meantime 😁 

**Completion port `HANDLE` registering**
In order to be able to wait for asynchronous I/O, `HANDLE` needs to be linked to a Completion Port. However, you can only register it once otherwise, the linking call fails. I first tried to let the user handle that by giving the possibility to link a handle to a `Loop`, but that ended up being unreliable and cumbersome when implementing Watchers.

My final decision was to ignore the failure and suppose that it always works. Win32 documentation is not what we could call exhaustive, so I don't if it's possible for an association to fail on the first call to `CreateIoCompletionPort` with a newly created `HANDLE`. Worst scenario is that it fails silently and asynchronous wait on this `HANDLE` never completes. If anyone has an idea as to how we could properly solve that, don't hesitate 😁 

**UDP Benchmark tweaks**
This is described in #38

**Process support**
I didn't implement support for `Process` watchers yet. I feel like it's not required to merge this (already big) PR. I'll see if adding support is possible in the future.