### PR TITLE
Fix dangling next pointer in heap.zig

### DIFF
--- a/src/heap.zig
+++ b/src/heap.zig
@@ -109,6 +109,7 @@ pub fn Intrusive(
                 if (b.heap.next) |b_next| {
                     a.heap.next = b_next;
                     b_next.heap.prev = a;
+                    b.heap.next = null;
                 }
 
                 // If A has a child, then B becomes the leftmost sibling

--- a/src/heap.zig
+++ b/src/heap.zig
@@ -386,3 +386,33 @@ test "dangling next pointer" {
 
     //printDotGraph(Elem, h.root.?);
 }
+
+// Use printDotGraph to get visual representation of the heap.
+// For example (run test with printDotGraph in it, remove start end lines, use dot cli to create image):
+// zig test --test-filter dangling heap.zig 2>&1 | cat | sed '/dangling/,/^OK/!d;//d' |  dot -Tsvg > out.svg && open out.svg
+//
+// Or just copy digraph and paste it to the https://dreampuf.github.io/GraphvizOnline/
+fn printDotGraph(comptime T: type, root: *T) void {
+    const print = std.debug.print;
+    print("\ndigraph {{\n", .{});
+    printPointers(T, root, null);
+    print("}}\n", .{});
+}
+
+fn printPointers(comptime T: type, e: *T, prev: ?*T) void {
+    const print = std.debug.print;
+    if (prev) |p| {
+        if (e.heap.prev != p) {
+            print("\t{d} -> {d} [label=\"prev missing\"];\n", .{ e.value, p.value });
+            print("\t{d} -> {d} [label=\"prev\"];\n", .{ e.value, e.heap.prev.?.value });
+        }
+    }
+    if (e.heap.child) |c| {
+        print("\t{d} -> {d} [label=\"child\"];\n", .{ e.value, c.value });
+        printPointers(T, c, e);
+    }
+    if (e.heap.next) |n| {
+        print("\t{d} -> {d} [label=\"next\"];\n", .{ e.value, n.value });
+        printPointers(T, n, e);
+    }
+}


### PR DESCRIPTION
I think that I found a bug in the heap.zig.

I have build a heap which looks like this: 
![before_remove](https://github.com/mitchellh/libxev/assets/35909/ee332e26-393a-41a4-b8c3-63f02ddc1825)
The next action was removing of element 88 (root). That resulted in heap:
![after_remove](https://github.com/mitchellh/libxev/assets/35909/1043432d-c58e-41f1-953b-a671dcd6d463)
Element 92 is both next of 94 and child of 91 which is, I think, wrong.
When B next is moved to the A next in the meld function B next pointer should be set to null.
After the fix, resulting heap looks like:
![fixed](https://github.com/mitchellh/libxev/assets/35909/b4fc19de-daa9-4219-a5fa-83bc1df404c7)

