### PR TITLE
Fix loop active count in kqueue backend for cancellations

### DIFF
--- a/src/backend/kqueue.zig
+++ b/src/backend/kqueue.zig
@@ -882,6 +882,7 @@ pub const Loop = struct {
             // to the submission queue (because its the same syscall) but
             // setting the state to deleting.
             if (c.kevent() != null) {
+                self.active -= 1;
                 c.flags.state = .deleting;
                 self.submissions.push(c);
                 return;


### PR DESCRIPTION
I started tcp server which runs accept loop. In idle state there is one active completion, those with accept operation. I tried to cancel that operation and although got both callback; of the accept and of the cancel loop(.until_done) did not finish because loop.active is 1 not 0. 
It seems that non timer cancelations are not handling loop.active counter correctly. 

I'm not absolutely sure that line 885 is the right place to decrement active count...