### PR TITLE
Update Zig, Adopt 0.11 Package Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,34 @@ int main(void) {
 </tr>
 </table>
 
+## Installation (Zig)
+
+**These instructions are for Zig downstream users only.** If you are
+using the C API to libxev, see the "Build" section.
+
+This package works with Zig package manager introduces in Zig 0.11.
+Create a `build.zig.zon` file like this:
+
+```zig
+.{
+    .name = "my-project",
+    .version = "0.0.0",
+    .dependencies = .{
+        .libxev = .{
+            .url = "https://github.com/mitchellh/libxev/archive/<git-ref-here>.tar.gz",
+            .hash = "12208070233b17de6be05e32af096a6760682b48598323234824def41789e993432c",
+        },
+    },
+}
+```
+
+And in your `build.zig`:
+
+```zig
+const xev = b.dependency("libxev", .{ .target = target, .optimize = optimize });
+exe.addModule("xev", xev.module("xev"));
+```
+
 ## Documentation
 
 🚧 Documentation is a work-in-progress. 🚧

--- a/build.zig
+++ b/build.zig
@@ -111,8 +111,11 @@ pub fn build(b: *std.Build) !void {
             .optimize = optimize,
         });
         static_binding_test.linkLibC();
-        static_binding_test.addIncludePath("include");
-        static_binding_test.addCSourceFile("examples/_basic.c", &[_][]const u8{ "-Wall", "-Wextra", "-pedantic", "-std=c99", "-D_POSIX_C_SOURCE=199309L" });
+        static_binding_test.addIncludePath(.{ .path = "include" });
+        static_binding_test.addCSourceFile(.{
+            .file = .{ .path = "examples/_basic.c" },
+            .flags = &[_][]const u8{ "-Wall", "-Wextra", "-pedantic", "-std=c99", "-D_POSIX_C_SOURCE=199309L" },
+        });
         static_binding_test.linkLibrary(static_lib);
         if (test_install) b.installArtifact(static_binding_test);
 
@@ -145,8 +148,11 @@ pub fn build(b: *std.Build) !void {
             .optimize = optimize,
         });
         dynamic_binding_test.linkLibC();
-        dynamic_binding_test.addIncludePath("include");
-        dynamic_binding_test.addCSourceFile("examples/_basic.c", &[_][]const u8{ "-Wall", "-Wextra", "-pedantic", "-std=c99" });
+        dynamic_binding_test.addIncludePath(.{ .path = "include" });
+        dynamic_binding_test.addCSourceFile(.{
+            .file = .{ .path = "examples/_basic.c" },
+            .flags = &[_][]const u8{ "-Wall", "-Wextra", "-pedantic", "-std=c99" },
+        });
         dynamic_binding_test.linkLibrary(dynamic_lib);
         if (test_install) b.installArtifact(dynamic_binding_test);
 
@@ -240,8 +246,12 @@ fn benchTargets(
             .optimize = .ReleaseFast, // benchmarks are always release fast
         });
         c_exe.addModule("xev", module(b));
-        c_exe.override_dest_dir = std.Build.InstallDir{ .custom = "bench" };
-        if (install) b.installArtifact(c_exe);
+        if (install) {
+            const install_step = b.addInstallArtifact(c_exe, .{
+                .dest_dir = .{ .override = .{ .custom = "bench" } },
+            });
+            b.getInstallStep().dependOn(&install_step.step);
+        }
 
         // Store the mapping
         try map.put(try b.allocator.dupe(u8, name), c_exe);
@@ -294,8 +304,12 @@ fn exampleTargets(
                 .optimize = optimize,
             });
             c_exe.addModule("xev", module(b));
-            c_exe.override_dest_dir = std.Build.InstallDir{ .custom = "example" };
-            if (install) b.installArtifact(c_exe);
+            if (install) {
+                const install_step = b.addInstallArtifact(c_exe, .{
+                    .dest_dir = .{ .override = .{ .custom = "example" } },
+                });
+                b.getInstallStep().dependOn(&install_step.step);
+            }
         } else {
             const c_lib = c_lib_ orelse return error.UnsupportedPlatform;
             const c_exe = b.addExecutable(.{
@@ -304,17 +318,24 @@ fn exampleTargets(
                 .optimize = optimize,
             });
             c_exe.linkLibC();
-            c_exe.addIncludePath("include");
-            c_exe.addCSourceFile(path, &[_][]const u8{
-                "-Wall",
-                "-Wextra",
-                "-pedantic",
-                "-std=c99",
-                "-D_POSIX_C_SOURCE=199309L",
+            c_exe.addIncludePath(.{ .path = "include" });
+            c_exe.addCSourceFile(.{
+                .file = .{ .path = path },
+                .flags = &[_][]const u8{
+                    "-Wall",
+                    "-Wextra",
+                    "-pedantic",
+                    "-std=c99",
+                    "-D_POSIX_C_SOURCE=199309L",
+                },
             });
             c_exe.linkLibrary(c_lib);
-            c_exe.override_dest_dir = std.Build.InstallDir{ .custom = "example" };
-            if (install) b.installArtifact(c_exe);
+            if (install) {
+                const install_step = b.addInstallArtifact(c_exe, .{
+                    .dest_dir = .{ .override = .{ .custom = "example" } },
+                });
+                b.getInstallStep().dependOn(&install_step.step);
+            }
         }
 
         // If we have specified a specific name, only install that one.

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,4 @@
+.{
+    .name = "libxev",
+    .version = "0.0.0",
+}

--- a/flake.lock
+++ b/flake.lock
@@ -126,11 +126,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1689899128,
-        "narHash": "sha256-jlWnAn+KLgEsJzl9KPABOZrZ7gYmgUHDLfQLskY2O4g=",
+        "lastModified": 1691064519,
+        "narHash": "sha256-kGl2GigkW6O7uVc5W4mFdn9SN2fOBpKdvbhSxZj/huQ=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "7af90962d9271745087d287248afe2766b58fb71",
+        "rev": "8a0bae25fcebaacdd117df045271778ffbb10735",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This updates Zig to nearly 0.11 (likely one or two days away). This also enforces the Zig package manager as the one true way.