### PR TITLE
Fix File.init() API documentation

### DIFF
--- a/src/watcher/file.zig
+++ b/src/watcher/file.zig
@@ -37,9 +37,7 @@ pub fn File(comptime xev: type) type {
             .threadpool = true,
         });
 
-        /// Initialize a new TCP with the family from the given address. Only
-        /// the family is used, the actual address has no impact on the created
-        /// resource.
+        /// Initialize a File from a std.fs.File.
         pub fn init(file: std.fs.File) !Self {
             return .{
                 .fd = file.handle,


### PR DESCRIPTION
Fix the copy-paste from TCP.init().