### PR TITLE
Fix for `epoll` backend: use duplicated `fd`

### DIFF
--- a/src/backend/epoll.zig
+++ b/src/backend/epoll.zig
@@ -728,7 +728,8 @@ pub const Loop = struct {
 
     fn stop_completion(self: *Loop, completion: *Completion) void {
         // Delete. This should never fail.
-        if (completion.fd()) |fd| {
+        const maybe_fd = if (completion.flags.dup) completion.flags.dup_fd else completion.fd();
+        if (maybe_fd) |fd| {
             std.os.epoll_ctl(
                 self.fd,
                 linux.EPOLL.CTL_DEL,


### PR DESCRIPTION
# Description
While playing with cancellation on an old machine not supporting `io_uring`, I noticed that it was using the original `fd`, thus causing a `error.FileDescriptorNotRegistered` to appear.

# Solution
Use the duplicated `fd` if the `completion.flags.dup` boolean is set, otherwise fallback to the `completion.fd` function.