### PR TITLE
update to Zig after #18085 (rework std.atomic) and #18076 (absorb IterableDir into Dir)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Install zig
       uses: goto-bus-stop/setup-zig@v2
       with:
-        version: 0.12.0-dev.1245+a07f288eb
+        version: 0.12.0-dev.1710+2bffd8101
 
     - name: test
       run: zig build test --summary all

--- a/build.zig
+++ b/build.zig
@@ -201,7 +201,7 @@ fn benchTargets(
 
     // Open the directory
     const c_dir_path = (comptime thisDir()) ++ "/src/bench";
-    var c_dir = try std.fs.openIterableDirAbsolute(c_dir_path, .{});
+    var c_dir = try std.fs.openDirAbsolute(c_dir_path, .{ .iterate = true });
     defer c_dir.close();
 
     // Go through and add each as a step
@@ -258,7 +258,7 @@ fn exampleTargets(
 
     // Open the directory
     const c_dir_path = (comptime thisDir()) ++ "/examples";
-    var c_dir = try std.fs.openIterableDirAbsolute(c_dir_path, .{});
+    var c_dir = try std.fs.openDirAbsolute(c_dir_path, .{ .iterate = true });
     defer c_dir.close();
 
     // Go through and add each as a step

--- a/flake.lock
+++ b/flake.lock
@@ -126,11 +126,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1700526194,
-        "narHash": "sha256-/7C9bzFG0Gq/tBAbSwC84Dg5TNPomCcxIJJQNj3Y2BI=",
+        "lastModified": 1700827703,
+        "narHash": "sha256-EfM3pRvtb5TrvxURhtI1gEKb/mSXHJx3A/12HOWKOyI=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "2877b025231e96196469ee8a5b80799027b42e03",
+        "rev": "2c9179e22a4759c7c88438a4a9eb0f5e3c00d3b0",
         "type": "github"
       },
       "original": {

--- a/src/backend/iocp.zig
+++ b/src/backend/iocp.zig
@@ -1272,7 +1272,7 @@ pub const Operation = union(OperationType) {
     },
 
     async_wait: struct {
-        wakeup: std.atomic.Atomic(bool) = .{ .value = false },
+        wakeup: std.atomic.Value(bool) = .{ .raw = false },
     },
 
     job_object: struct {

--- a/src/bench/async_pummel_1.zig
+++ b/src/bench/async_pummel_1.zig
@@ -30,7 +30,7 @@ pub fn run(comptime thread_count: comptime_int) !void {
     notifier = try xev.Async.init();
     defer notifier.deinit();
 
-    var userdata: ?*void = null;
+    const userdata: ?*void = null;
     var c: xev.Completion = undefined;
     notifier.wait(&loop, &c, void, userdata, &asyncCallback);
 

--- a/src/build/ScdocStep.zig
+++ b/src/build/ScdocStep.zig
@@ -63,7 +63,7 @@ fn make(step: *std.build.Step, progress: *std.Progress.Node) !void {
     }
 
     // Find all our man pages which are in our src path ending with ".scd".
-    var dir = try fs.openIterableDirAbsolute(self.src_path, .{});
+    var dir = try fs.openDirAbsolute(self.src_path, .{ .iterate = true });
     defer dir.close();
 
     var iter = dir.iterate();
@@ -138,7 +138,7 @@ const InstallStep = struct {
         }
 
         // Find all our man pages which are in our src path ending with ".scd".
-        var dir = try fs.openIterableDirAbsolute(path, .{});
+        var dir = try fs.openDirAbsolute(path, .{ .iterate = true });
         defer dir.close();
         var iter = dir.iterate();
         while (try iter.next()) |*entry| {


### PR DESCRIPTION
Also fixes `never mutated var` in a benchmark missed earlier