### PR TITLE
Fix breaking changes in most recent nightly build

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,6 @@
 .{
     .name = "libxev",
+    .minimum_zig_version = "0.12.0-dev.3191+9cf28d1e9",
     .paths = .{""},
     .version = "0.0.0",
 }

--- a/flake.lock
+++ b/flake.lock
@@ -126,11 +126,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1704500574,
-        "narHash": "sha256-Ockm1D5QsxdVZZoD0Yf5Kg4FupbVnk3X0RLkc6geRIE=",
+        "lastModified": 1710028389,
+        "narHash": "sha256-NjtsA9aTb9qgzmuuXJabVL0LeNw8ae3BXpF/+UCT2yc=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "e056aafd8db157ff7519518a026c5ba7040522cf",
+        "rev": "7e2da66bd83f27441d2a3244ebdc7d0b4d20c3c4",
         "type": "github"
       },
       "original": {

--- a/src/backend/iocp.zig
+++ b/src/backend/iocp.zig
@@ -1955,7 +1955,7 @@ test "iocp: socket accept/connect/send/recv/close" {
     const address = try net.Address.parseIp4("127.0.0.1", 3131);
     const kernel_backlog = 1;
     const ln = try windows.WSASocketW(std.os.AF.INET, std.os.SOCK.STREAM, std.os.IPPROTO.TCP, null, 0, windows.ws2_32.WSA_FLAG_OVERLAPPED);
-    errdefer std.os.closeSocket(ln);
+    errdefer std.os.close(ln);
 
     try std.os.setsockopt(ln, std.os.SOL.SOCKET, std.os.SO.REUSEADDR, &mem.toBytes(@as(c_int, 1)));
     try std.os.bind(ln, &address.any, address.getOsSockLen());
@@ -1963,7 +1963,7 @@ test "iocp: socket accept/connect/send/recv/close" {
 
     // Create a TCP client socket
     const client_conn = try windows.WSASocketW(std.os.AF.INET, std.os.SOCK.STREAM, std.os.IPPROTO.TCP, null, 0, windows.ws2_32.WSA_FLAG_OVERLAPPED);
-    errdefer std.os.closeSocket(client_conn);
+    errdefer std.os.close(client_conn);
 
     var server_conn_result: Result = undefined;
     var c_accept: Completion = .{
@@ -2221,7 +2221,7 @@ test "iocp: recv cancellation" {
     // Create a TCP server socket
     const address = try net.Address.parseIp4("127.0.0.1", 3131);
     const socket = try windows.WSASocketW(std.os.AF.INET, std.os.SOCK.DGRAM, std.os.IPPROTO.UDP, null, 0, windows.ws2_32.WSA_FLAG_OVERLAPPED);
-    errdefer std.os.closeSocket(socket);
+    errdefer std.os.close(socket);
 
     try std.os.setsockopt(socket, std.os.SOL.SOCKET, std.os.SO.REUSEADDR, &mem.toBytes(@as(c_int, 1)));
     try std.os.bind(socket, &address.any, address.getOsSockLen());
@@ -2294,7 +2294,7 @@ test "iocp: accept cancellation" {
     const address = try net.Address.parseIp4("127.0.0.1", 3131);
     const kernel_backlog = 1;
     const ln = try windows.WSASocketW(std.os.AF.INET, std.os.SOCK.STREAM, std.os.IPPROTO.TCP, null, 0, windows.ws2_32.WSA_FLAG_OVERLAPPED);
-    errdefer std.os.closeSocket(ln);
+    errdefer std.os.close(ln);
 
     try std.os.setsockopt(ln, std.os.SOL.SOCKET, std.os.SO.REUSEADDR, &mem.toBytes(@as(c_int, 1)));
     try std.os.bind(ln, &address.any, address.getOsSockLen());

--- a/src/backend/kqueue.zig
+++ b/src/backend/kqueue.zig
@@ -2133,7 +2133,7 @@ test "kqueue: socket accept/connect/send/recv/close" {
     const address = try net.Address.parseIp4("127.0.0.1", 3131);
     const kernel_backlog = 1;
     var ln = try os.socket(address.any.family, os.SOCK.STREAM | os.SOCK.CLOEXEC, 0);
-    errdefer os.closeSocket(ln);
+    errdefer os.close(ln);
     try os.setsockopt(ln, os.SOL.SOCKET, os.SO.REUSEADDR, &mem.toBytes(@as(c_int, 1)));
     try os.bind(ln, &address.any, address.getOsSockLen());
     try os.listen(ln, kernel_backlog);
@@ -2144,7 +2144,7 @@ test "kqueue: socket accept/connect/send/recv/close" {
         os.SOCK.NONBLOCK | os.SOCK.STREAM | os.SOCK.CLOEXEC,
         0,
     );
-    errdefer os.closeSocket(client_conn);
+    errdefer os.close(client_conn);
 
     // Accept
     var server_conn: os.socket_t = 0;
@@ -2583,7 +2583,7 @@ test "kqueue: socket accept/cancel cancellation should decrease active count" {
     const address = try net.Address.parseIp4("127.0.0.1", 3131);
     const kernel_backlog = 1;
     var ln = try os.socket(address.any.family, os.SOCK.STREAM | os.SOCK.CLOEXEC, 0);
-    errdefer os.closeSocket(ln);
+    errdefer os.close(ln);
     try os.setsockopt(ln, os.SOL.SOCKET, os.SO.REUSEADDR, &mem.toBytes(@as(c_int, 1)));
     try os.bind(ln, &address.any, address.getOsSockLen());
     try os.listen(ln, kernel_backlog);

--- a/src/linux/timerfd.zig
+++ b/src/linux/timerfd.zig
@@ -13,7 +13,7 @@ pub const Timerfd = struct {
     fd: i32,
 
     /// timerfd_create
-    pub fn init(clock: Clock, flags: u32) !Timerfd {
+    pub fn init(clock: Clock, flags: linux.TFD) !Timerfd {
         const res = linux.timerfd_create(@intFromEnum(clock), flags);
         return switch (linux.getErrno(res)) {
             .SUCCESS => .{ .fd = @as(i32, @intCast(res)) },
@@ -28,7 +28,7 @@ pub const Timerfd = struct {
     /// timerfd_settime
     pub fn set(
         self: *const Timerfd,
-        flags: u32,
+        flags: linux.TFD.TIMER,
         new_value: *const Spec,
         old_value: ?*Spec,
     ) !void {
@@ -83,15 +83,15 @@ pub const Timerfd = struct {
 test Timerfd {
     const testing = std.testing;
 
-    var t = try Timerfd.init(.monotonic, 0);
+    var t = try Timerfd.init(.monotonic, .{});
     defer t.deinit();
 
     // Set
-    try t.set(0, &.{ .value = .{ .seconds = 60 } }, null);
+    try t.set(.{}, &.{ .value = .{ .seconds = 60 } }, null);
     try testing.expect((try t.get()).value.seconds > 0);
 
     // Disarm
     var old: Timerfd.Spec = undefined;
-    try t.set(0, &.{ .value = .{ .seconds = 0 } }, &old);
+    try t.set(.{}, &.{ .value = .{ .seconds = 0 } }, &old);
     try testing.expect(old.value.seconds > 0);
 }


### PR DESCRIPTION
Hi there — big fan of libxev! Noticed some recent Zig changes (namely, this [commit](https://github.com/ziglang/zig/commit/265f42d472fa110c1e211e5f82fdf540ee198aa8) + some other recent ones), broke a bunch of stuff in here. Went through and did updates to get libxev working with the latest nightly build (`0.12.0-dev.3191+9cf28d1e9`), and tested the changes on both macOS and Linux.

Don't have a windows machine, so I expect more changes might be needed. Also, mlugg seems like he's on a `std.os` refactor spree, so we might need to do even more updates here eventually.