### PR TITLE
Remove useless files in Zig package

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,12 @@
 .{
     .name = "libxev",
     .minimum_zig_version = "0.12.0-dev.3191+9cf28d1e9",
-    .paths = .{""},
+    .paths = .{
+        "README.md",
+        "LICENSE",
+        "build.zig",
+        "build.zig.zon",
+        "src/",
+    },
     .version = "0.0.0",
 }


### PR DESCRIPTION
Closes #87 

I wasn't sure if "include/" could be required. The only usecase I see is if someone uses the Zig build system for a C project and wants to use `libxev` as a C library.