### PR TITLE
fix @fieldParentPtr

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = "libxev",
-    .minimum_zig_version = "0.12.0-dev.3191+9cf28d1e9",
+    .minimum_zig_version = "0.12.0-dev.3508+a6ed3e6d2",
     .paths = .{""},
     .version = "0.0.0",
 }

--- a/src/ThreadPool.zig
+++ b/src/ThreadPool.zig
@@ -376,7 +376,7 @@ const Thread = struct {
                     thread_pool.notify(is_waking);
                 is_waking = false;
 
-                const task = @fieldParentPtr(Task, "node", result.node);
+                const task: *Task = @fieldParentPtr("node", result.node);
                 (task.callback)(task);
             }
         }

--- a/src/backend/epoll.zig
+++ b/src/backend/epoll.zig
@@ -429,7 +429,7 @@ pub const Loop = struct {
     /// This is the main callback for the threadpool to perform work
     /// on completions for the loop.
     fn thread_perform(t: *ThreadPool.Task) void {
-        const c = @fieldParentPtr(Completion, "task", t);
+        const c: *Completion = @fieldParentPtr("task", t);
 
         // Do our task
         c.task_result = c.perform();

--- a/src/backend/iocp.zig
+++ b/src/backend/iocp.zig
@@ -323,7 +323,7 @@ pub const Loop = struct {
                         continue;
                     }
 
-                    break :completion @fieldParentPtr(Completion, "overlapped", overlapped_ptr.?);
+                    break :completion @fieldParentPtr("overlapped", overlapped_ptr.?);
                 } else completion: {
                     // JobObjects are a special case where the OVERLAPPED_ENTRY fields are interpreted differently.
                     // When JOBOBJECT_ASSOCIATE_COMPLETION_PORT is used, lpOverlapped actually contains the message

--- a/src/backend/kqueue.zig
+++ b/src/backend/kqueue.zig
@@ -933,7 +933,7 @@ pub const Loop = struct {
     /// This is the main callback for the threadpool to perform work
     /// on completions for the loop.
     fn thread_perform(t: *ThreadPool.Task) void {
-        const c = @fieldParentPtr(Completion, "task", t);
+        const c: *Completion = @fieldParentPtr("task", t);
 
         // Do our task
         c.result = c.perform(null);

--- a/src/build/ScdocStep.zig
+++ b/src/build/ScdocStep.zig
@@ -49,7 +49,7 @@ pub fn init(builder: *Build) ScdocStep {
 fn make(step: *std.Build.Step, progress: *std.Progress.Node) !void {
     _ = progress;
 
-    const self = @fieldParentPtr(ScdocStep, "step", step);
+    const self: *ScdocStep = @fieldParentPtr("step", step);
 
     // Create our cache path
     // TODO(mitchellh): ideally this would be pure zig
@@ -129,7 +129,7 @@ const InstallStep = struct {
     }
 
     fn make(step: *Step, progress: *std.Progress.Node) !void {
-        const self = @fieldParentPtr(InstallStep, "step", step);
+        const self: *InstallStep = @fieldParentPtr("step", step);
 
         // Get our absolute output path
         var path = self.scdoc.out_path;

--- a/src/c_api.zig
+++ b/src/c_api.zig
@@ -97,11 +97,11 @@ export fn xev_threadpool_task_init(
     t.* = .{
         .callback = (struct {
             fn callback(inner_t: *xev.ThreadPool.Task) void {
-                @fieldParentPtr(
-                    Task,
+                const task: *Task = @alignCast(@fieldParentPtr(
                     "data",
                     @as(*Task.Data, @ptrCast(inner_t)),
-                ).c_callback(inner_t);
+                ));
+                task.c_callback(inner_t);
             }
         }).callback,
     };

--- a/src/watcher/stream.zig
+++ b/src/watcher/stream.zig
@@ -220,7 +220,7 @@ pub fn Writeable(comptime xev: type, comptime T: type, comptime options: Options
             /// originally is from a write request. This is useful for getting
             /// the WriteRequest back in a callback from queuedWrite.
             pub fn from(c: *xev.Completion) *WriteRequest {
-                return @fieldParentPtr(WriteRequest, "completion", c);
+                return @fieldParentPtr("completion", c);
             }
         };
 


### PR DESCRIPTION
@fieldParentPtr takes only two arguments now and uses RLS to infer the result type.
See ziglang/zig#19470