### PR TITLE
docs: Document way to add libxev as a dependency with `zig` cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,14 @@ Create a `build.zig.zon` file like this:
 }
 ```
 
+Or you can run:
+
+```bash
+zig fetch --save https://github.com/mitchellh/libxev/archive/refs/heads/main.tar.gz
+```
+
+To add it into your `build.zig.zon`
+
 And in your `build.zig`:
 
 ```zig


### PR DESCRIPTION
Just a proposed nicety for the docs. 