### PR TITLE
build: prevent breakage with relative paths

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -205,7 +205,7 @@ fn benchTargets(
 
     // Open the directory
     const c_dir_path = (comptime thisDir()) ++ "/src/bench";
-    var c_dir = try std.fs.openDirAbsolute(c_dir_path, .{ .iterate = true });
+    var c_dir = try std.fs.cwd().openDir(c_dir_path, .{ .iterate = true });
     defer c_dir.close();
 
     // Go through and add each as a step
@@ -262,7 +262,7 @@ fn exampleTargets(
 
     // Open the directory
     const c_dir_path = (comptime thisDir()) ++ "/examples";
-    var c_dir = try std.fs.openDirAbsolute(c_dir_path, .{ .iterate = true });
+    var c_dir = try std.fs.cwd().openDir(c_dir_path, .{ .iterate = true });
     defer c_dir.close();
 
     // Go through and add each as a step


### PR DESCRIPTION
`thisDir()` returns `@src().file` which isn't always an absolute path

