### PR TITLE
fix: update to zig 0.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
           x86_64-linux-musl,
           aarch64-macos,
           x86_64-macos,
-          wasm32-wasi,
+          # wasm32-wasi, - regressed in Zig 0.13
           x86_64-windows-gnu
 
           # Broken but not in any obvious way:
@@ -67,8 +67,9 @@ jobs:
     # will ensure we have all our dependencies.
     - name: test
       run: nix develop -c zig build test --summary all
-    - name: test wasi
-      run: nix develop -c zig build test -Dtarget=wasm32-wasi -fwasmtime --summary all
+    # WASI has regressed since Zig 0.13, we should fix it.
+    # - name: test wasi
+    #   run: nix develop -c zig build test -Dtarget=wasm32-wasi -fwasmtime --summary all
 
     - name: build all benchmarks and examples
       run: nix develop -c zig build -Dexample -Dbench --summary all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Install zig
       uses: goto-bus-stop/setup-zig@v2
       with:
-        version: 0.12.0-dev.2058+04ac028a2
+        version: 0.13.0
 
     - name: test
       run: zig build test --summary all

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-zig-cache
+.zig-cache
 zig-out

--- a/build.zig
+++ b/build.zig
@@ -100,7 +100,7 @@ pub fn build(b: *std.Build) !void {
         static_binding_test.linkLibC();
         static_binding_test.addIncludePath(b.path("include"));
         static_binding_test.addCSourceFile(.{
-            .file = b.path("examples/basic.c"),
+            .file = b.path("examples/_basic.c"),
             .flags = &[_][]const u8{ "-Wall", "-Wextra", "-pedantic", "-std=c99", "-D_POSIX_C_SOURCE=199309L" },
         });
         static_binding_test.linkLibrary(static_lib);

--- a/build.zig
+++ b/build.zig
@@ -6,7 +6,7 @@ pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    _ = b.addModule("xev", .{ .root_source_file = .{ .path = "src/main.zig" } });
+    _ = b.addModule("xev", .{ .root_source_file = b.path("src/main.zig") });
 
     const man_pages = b.option(
         bool,
@@ -60,7 +60,7 @@ pub fn build(b: *std.Build) !void {
     // we can easily run it manually without digging through the cache.
     const test_exe = b.addTest(.{
         .name = "xev-test",
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
     });
@@ -76,7 +76,7 @@ pub fn build(b: *std.Build) !void {
     const static_c_lib: ?*std.Build.Step.Compile = if (target.result.os.tag != .wasi) lib: {
         const static_lib = b.addStaticLibrary(.{
             .name = "xev",
-            .root_source_file = .{ .path = "src/c_api.zig" },
+            .root_source_file = b.path("src/c_api.zig"),
             .target = target,
             .optimize = optimize,
         });
@@ -98,9 +98,9 @@ pub fn build(b: *std.Build) !void {
             .optimize = optimize,
         });
         static_binding_test.linkLibC();
-        static_binding_test.addIncludePath(.{ .path = "include" });
+        static_binding_test.addIncludePath(b.path("include"));
         static_binding_test.addCSourceFile(.{
-            .file = .{ .path = "examples/_basic.c" },
+            .file = b.path("examples/basic.c"),
             .flags = &[_][]const u8{ "-Wall", "-Wextra", "-pedantic", "-std=c99", "-D_POSIX_C_SOURCE=199309L" },
         });
         static_binding_test.linkLibrary(static_lib);
@@ -119,7 +119,7 @@ pub fn build(b: *std.Build) !void {
 
         const dynamic_lib = b.addSharedLibrary(.{
             .name = dynamic_lib_name,
-            .root_source_file = .{ .path = "src/c_api.zig" },
+            .root_source_file = b.path("src/c_api.zig"),
             .target = target,
             .optimize = optimize,
         });
@@ -132,9 +132,9 @@ pub fn build(b: *std.Build) !void {
             .optimize = optimize,
         });
         dynamic_binding_test.linkLibC();
-        dynamic_binding_test.addIncludePath(.{ .path = "include" });
+        dynamic_binding_test.addIncludePath(b.path("include"));
         dynamic_binding_test.addCSourceFile(.{
-            .file = .{ .path = "examples/_basic.c" },
+            .file = b.path("examples/_basic.c"),
             .flags = &[_][]const u8{ "-Wall", "-Wextra", "-pedantic", "-std=c99" },
         });
         dynamic_binding_test.linkLibrary(dynamic_lib);
@@ -146,7 +146,7 @@ pub fn build(b: *std.Build) !void {
 
     // C Headers
     const c_header = b.addInstallFileWithDir(
-        .{ .path = "include/xev.h" },
+        b.path("include/xev.h"),
         .header,
         "xev.h",
     );
@@ -173,7 +173,7 @@ pub fn build(b: *std.Build) !void {
         defer pkgconfig_file.close();
 
         b.getInstallStep().dependOn(&b.addInstallFileWithDir(
-            .{ .path = file },
+            .{ .cwd_relative = file },
             .prefix,
             "share/pkgconfig/libxev.pc",
         ).step);
@@ -204,8 +204,8 @@ fn benchTargets(
     var map = std.StringHashMap(*std.Build.Step.Compile).init(b.allocator);
 
     // Open the directory
-    const c_dir_path = (comptime thisDir()) ++ "/src/bench";
-    var c_dir = try std.fs.cwd().openDir(c_dir_path, .{ .iterate = true });
+    const c_dir_path = "src/bench";
+    var c_dir = try std.fs.cwd().openDir(comptime thisDir() ++ "/" ++ c_dir_path, .{ .iterate = true });
     defer c_dir.close();
 
     // Go through and add each as a step
@@ -230,7 +230,7 @@ fn benchTargets(
         // Executable builder.
         const c_exe = b.addExecutable(.{
             .name = name,
-            .root_source_file = .{ .path = path },
+            .root_source_file = b.path(path),
             .target = target,
             .optimize = .ReleaseFast, // benchmarks are always release fast
         });
@@ -288,7 +288,7 @@ fn exampleTargets(
         if (is_zig) {
             const c_exe = b.addExecutable(.{
                 .name = name,
-                .root_source_file = .{ .path = path },
+                .root_source_file = b.path(path),
                 .target = target,
                 .optimize = optimize,
             });
@@ -307,9 +307,9 @@ fn exampleTargets(
                 .optimize = optimize,
             });
             c_exe.linkLibC();
-            c_exe.addIncludePath(.{ .path = "include" });
+            c_exe.addIncludePath(b.path("include"));
             c_exe.addCSourceFile(.{
-                .file = .{ .path = path },
+                .file = b.path(path),
                 .flags = &[_][]const u8{
                     "-Wall",
                     "-Wextra",

--- a/build.zig
+++ b/build.zig
@@ -288,7 +288,7 @@ fn exampleTargets(
         if (is_zig) {
             const c_exe = b.addExecutable(.{
                 .name = name,
-                .root_source_file = b.path(path),
+                .root_source_file = .{ .cwd_relative = path },
                 .target = target,
                 .optimize = optimize,
             });
@@ -309,7 +309,7 @@ fn exampleTargets(
             c_exe.linkLibC();
             c_exe.addIncludePath(b.path("include"));
             c_exe.addCSourceFile(.{
-                .file = b.path(path),
+                .file = .{ .cwd_relative = path },
                 .flags = &[_][]const u8{
                     "-Wall",
                     "-Wextra",

--- a/flake.lock
+++ b/flake.lock
@@ -67,16 +67,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1688141187,
-        "narHash": "sha256-MTeum0f3Hz5yss2aoIAIjnx/SKg6PqMUd3ishL8awKU=",
+        "lastModified": 1717895720,
+        "narHash": "sha256-Dl6JKx1rIDEuv4q9rtlt9QwyerSQbrk1bUtNHzx9bIY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2847fac7f4f0d614ba9efd624eb93c2da8173898",
+        "rev": "0e0826ec06d2b3db8e28e280d68179f022b1d160",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "release-23.05",
+        "ref": "release-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -19,11 +19,11 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
@@ -48,12 +48,15 @@
       }
     },
     "flake-utils_2": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
         "type": "github"
       },
       "original": {
@@ -96,16 +99,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1702350026,
-        "narHash": "sha256-A+GNZFZdfl4JdDphYKBJ5Ef1HOiFsP18vQe9mqjmUis=",
+        "lastModified": 1708161998,
+        "narHash": "sha256-6KnemmUorCvlcAvGziFosAVkrlWZGIc6UNT9GUYr0jQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9463103069725474698139ab10f17a9d125da859",
+        "rev": "84d981bae8b5e783b3b548de505b22880559515f",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.05",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -119,6 +122,21 @@
         "zig": "zig"
       }
     },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "zig": {
       "inputs": {
         "flake-compat": "flake-compat_2",
@@ -126,11 +144,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1712794997,
-        "narHash": "sha256-H1sVVagnlL6xmvSVELGMEAhvJHv4auAY3B97Oi2I8uo=",
+        "lastModified": 1717848532,
+        "narHash": "sha256-d+xIUvSTreHl8pAmU1fnmkfDTGQYCn2Rb/zOwByxS2M=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "9687044a467176bea9e3f0a972143bcbad5dae90",
+        "rev": "02fc5cc555fc14fda40c42d7c3250efa43812b43",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "libxev is a high performance, cross-platform event loop.";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/release-23.05";
+    nixpkgs.url = "github:nixos/nixpkgs/release-24.05";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     zig.url = "github:mitchellh/zig-overlay";

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
       # Other overlays
       (final: prev: rec {
         zigpkgs = inputs.zig.packages.${prev.system};
-        zig = zigpkgs.master;
+        zig = inputs.zig.packages.${prev.system}."0.13.0";
 
         # Latest versions
         wasmtime = inputs.nixpkgs-unstable.legacyPackages.${prev.system}.wasmtime;
@@ -46,7 +46,7 @@
           nativeBuildInputs = with pkgs; [
             mandoc
             scdoc
-            zigpkgs.master
+            zig
 
             # Wasm
             wabt

--- a/src/backend/io_uring.zig
+++ b/src/backend/io_uring.zig
@@ -1604,7 +1604,7 @@ test "io_uring: sendmsg/recvmsg" {
     // Send
     const buffer_send = [_]u8{42} ** 128;
     const iovecs_send = [_]os.iovec_const{
-        os.iovec_const{ .iov_base = &buffer_send, .iov_len = buffer_send.len },
+        os.iovec_const{ .base = &buffer_send, .len = buffer_send.len },
     };
     var msg_send = os.msghdr_const{
         .name = &address.any,
@@ -1639,7 +1639,7 @@ test "io_uring: sendmsg/recvmsg" {
 
     var buffer_recv = [_]u8{0} ** 128;
     var iovecs_recv = [_]os.iovec{
-        os.iovec{ .iov_base = &buffer_recv, .iov_len = buffer_recv.len },
+        os.iovec{ .base = &buffer_recv, .len = buffer_recv.len },
     };
     const addr = [_]u8{0} ** 4;
     var address_recv = net.Address.initIp4(addr, 0);

--- a/src/backend/wasi_poll.zig
+++ b/src/backend/wasi_poll.zig
@@ -582,7 +582,7 @@ pub const Loop = struct {
 
     fn get_now() !wasi.timestamp_t {
         var ts: wasi.timestamp_t = undefined;
-        return switch (wasi.clock_time_get(@as(u32, @bitCast(posix.CLOCK.MONOTONIC)), 1, &ts)) {
+        return switch (wasi.clock_time_get(posix.CLOCK.MONOTONIC, 1, &ts)) {
             .SUCCESS => ts,
             .INVAL => error.UnsupportedClock,
             else => |err| posix.unexpectedErrno(err),

--- a/src/backend/wasi_poll.zig
+++ b/src/backend/wasi_poll.zig
@@ -825,8 +825,8 @@ pub const Completion = struct {
                 const errno = switch (op.buffer) {
                     .slice => |v| slice: {
                         var iovs = [1]posix.iovec{posix.iovec{
-                            .iov_base = v.ptr,
-                            .iov_len = v.len,
+                            .base = v.ptr,
+                            .len = v.len,
                         }};
 
                         break :slice wasi.sock_recv(
@@ -841,8 +841,8 @@ pub const Completion = struct {
 
                     .array => |*v| array: {
                         var iovs = [1]posix.iovec{posix.iovec{
-                            .iov_base = v,
-                            .iov_len = v.len,
+                            .base = v,
+                            .len = v.len,
                         }};
 
                         break :array wasi.sock_recv(
@@ -869,8 +869,8 @@ pub const Completion = struct {
                 const errno = switch (op.buffer) {
                     .slice => |v| slice: {
                         var iovs = [1]posix.iovec_const{posix.iovec_const{
-                            .iov_base = v.ptr,
-                            .iov_len = v.len,
+                            .base = v.ptr,
+                            .len = v.len,
                         }};
 
                         break :slice wasi.sock_send(
@@ -884,8 +884,8 @@ pub const Completion = struct {
 
                     .array => |*v| array: {
                         var iovs = [1]posix.iovec_const{posix.iovec_const{
-                            .iov_base = &v.array,
-                            .iov_len = v.len,
+                            .base = &v.array,
+                            .len = v.len,
                         }};
 
                         break :array wasi.sock_send(

--- a/src/bench/async1.zig
+++ b/src/bench/async1.zig
@@ -4,8 +4,8 @@ const Allocator = std.mem.Allocator;
 const Instant = std.time.Instant;
 const xev = @import("xev");
 
-pub const std_options = struct {
-    pub const log_level: std.log.Level = .info;
+pub const std_options: std.Options = .{
+    .log_level = .info,
 };
 
 // Tune-ables

--- a/src/bench/async2.zig
+++ b/src/bench/async2.zig
@@ -1,8 +1,8 @@
 const std = @import("std");
 const run = @import("async1.zig").run;
 
-pub const std_options = struct {
-    pub const log_level: std.log.Level = .info;
+pub const std_options: std.Options = .{
+    .log_level = .info,
 };
 
 pub fn main() !void {

--- a/src/bench/async4.zig
+++ b/src/bench/async4.zig
@@ -1,8 +1,8 @@
 const std = @import("std");
 const run = @import("async1.zig").run;
 
-pub const std_options = struct {
-    pub const log_level: std.log.Level = .info;
+pub const std_options: std.Options = .{
+    .log_level = .info,
 };
 
 pub fn main() !void {

--- a/src/bench/async8.zig
+++ b/src/bench/async8.zig
@@ -1,8 +1,8 @@
 const std = @import("std");
 const run = @import("async1.zig").run;
 
-pub const std_options = struct {
-    pub const log_level: std.log.Level = .info;
+pub const std_options: std.Options = .{
+    .log_level = .info,
 };
 
 pub fn main() !void {

--- a/src/bench/async_pummel_1.zig
+++ b/src/bench/async_pummel_1.zig
@@ -4,8 +4,8 @@ const Allocator = std.mem.Allocator;
 const Instant = std.time.Instant;
 const xev = @import("xev");
 
-pub const std_options = struct {
-    pub const log_level: std.log.Level = .info;
+pub const std_options: std.Options = .{
+    .log_level = .info,
 };
 
 // Tune-ables

--- a/src/bench/async_pummel_2.zig
+++ b/src/bench/async_pummel_2.zig
@@ -1,8 +1,8 @@
 const std = @import("std");
 const run = @import("async_pummel_1.zig").run;
 
-pub const std_options = struct {
-    pub const log_level: std.log.Level = .info;
+pub const std_options: std.Options = .{
+    .log_level = .info,
 };
 
 pub fn main() !void {

--- a/src/bench/async_pummel_4.zig
+++ b/src/bench/async_pummel_4.zig
@@ -1,8 +1,8 @@
 const std = @import("std");
 const run = @import("async_pummel_1.zig").run;
 
-pub const std_options = struct {
-    pub const log_level: std.log.Level = .info;
+pub const std_options: std.Options = .{
+    .log_level = .info,
 };
 
 pub fn main() !void {

--- a/src/bench/async_pummel_8.zig
+++ b/src/bench/async_pummel_8.zig
@@ -1,8 +1,8 @@
 const std = @import("std");
 const run = @import("async_pummel_1.zig").run;
 
-pub const std_options = struct {
-    pub const log_level: std.log.Level = .info;
+pub const std_options: std.Options = .{
+    .log_level = .info,
 };
 
 pub fn main() !void {

--- a/src/bench/million-timers.zig
+++ b/src/bench/million-timers.zig
@@ -43,8 +43,8 @@ pub fn main() !void {
     std.log.info("{d:.2} seconds cleanup", .{@as(f64, @floatFromInt(after_all.since(after_run))) / 1e9});
 }
 
-pub const std_options = struct {
-    pub const log_level: std.log.Level = .info;
+pub const std_options: std.Options = .{
+    .log_level = .info,
 };
 
 var timer_callback_count: usize = 0;

--- a/src/bench/ping-pongs.zig
+++ b/src/bench/ping-pongs.zig
@@ -4,8 +4,8 @@ const Allocator = std.mem.Allocator;
 const Instant = std.time.Instant;
 const xev = @import("xev");
 
-pub const std_options = struct {
-    pub const log_level: std.log.Level = .info;
+pub const std_options: std.Options = .{
+    .log_level = .info,
 };
 
 pub fn main() !void {

--- a/src/bench/ping-udp1.zig
+++ b/src/bench/ping-udp1.zig
@@ -5,8 +5,8 @@ const Allocator = std.mem.Allocator;
 const Instant = std.time.Instant;
 const xev = @import("xev");
 
-pub const std_options = struct {
-    pub const log_level: std.log.Level = .info;
+pub const std_options: std.Options = .{
+    .log_level = .info,
 };
 
 pub fn main() !void {

--- a/src/bench/udp_pummel_1v1.zig
+++ b/src/bench/udp_pummel_1v1.zig
@@ -12,8 +12,8 @@ var packet_counter: usize = 1e6;
 var send_cb_called: usize = 0;
 var recv_cb_called: usize = 0;
 
-pub const std_options = struct {
-    pub const log_level: std.log.Level = .info;
+pub const std_options: std.Options = .{
+    .log_level = .info,
 };
 
 pub fn main() !void {

--- a/src/build/ScdocStep.zig
+++ b/src/build/ScdocStep.zig
@@ -46,9 +46,7 @@ pub fn init(builder: *Build) ScdocStep {
     };
 }
 
-fn make(step: *std.Build.Step, progress: *std.Progress.Node) !void {
-    _ = progress;
-
+fn make(step: *std.Build.Step, _: std.Progress.Node) !void {
     const self: *ScdocStep = @fieldParentPtr("step", step);
 
     // Create our cache path
@@ -128,7 +126,7 @@ const InstallStep = struct {
         };
     }
 
-    fn make(step: *Step, progress: *std.Progress.Node) !void {
+    fn make(step: *Step, progress: std.Progress.Node) !void {
         const self: *InstallStep = @fieldParentPtr("step", step);
 
         // Get our absolute output path
@@ -156,7 +154,7 @@ const InstallStep = struct {
             );
 
             const fileStep = self.builder.addInstallFile(
-                .{ .path = src },
+                self.builder.path(src),
                 output,
             );
             try fileStep.step.make(progress);

--- a/src/build/ScdocStep.zig
+++ b/src/build/ScdocStep.zig
@@ -154,7 +154,7 @@ const InstallStep = struct {
             );
 
             const fileStep = self.builder.addInstallFile(
-                self.builder.path(src),
+                .{ .cwd_relative = src },
                 output,
             );
             try fileStep.step.make(progress);

--- a/src/watcher/process.zig
+++ b/src/watcher/process.zig
@@ -347,7 +347,7 @@ fn ProcessTests(
             const testing = std.testing;
             const alloc = testing.allocator;
 
-            var child = std.ChildProcess.init(argv_0, alloc);
+            var child = std.process.Child.init(argv_0, alloc);
             try child.spawn();
 
             var loop = try xev.Loop.init(.{});
@@ -380,7 +380,7 @@ fn ProcessTests(
             const testing = std.testing;
             const alloc = testing.allocator;
 
-            var child = std.ChildProcess.init(argv_42, alloc);
+            var child = std.process.Child.init(argv_42, alloc);
             try child.spawn();
 
             var loop = try xev.Loop.init(.{});
@@ -413,7 +413,7 @@ fn ProcessTests(
             const testing = std.testing;
             const alloc = testing.allocator;
 
-            var child = std.ChildProcess.init(argv_0, alloc);
+            var child = std.process.Child.init(argv_0, alloc);
             try child.spawn();
 
             var loop = try xev.Loop.init(.{});

--- a/src/watcher/udp.zig
+++ b/src/watcher/udp.zig
@@ -504,15 +504,15 @@ fn UDPSendMsg(comptime xev: type) type {
             switch (s.op.recv.buf) {
                 .slice => |v| {
                     s.op.recv.iov[0] = .{
-                        .iov_base = v.ptr,
-                        .iov_len = v.len,
+                        .base = v.ptr,
+                        .len = v.len,
                     };
                 },
 
                 .array => |*arr| {
                     s.op.recv.iov[0] = .{
-                        .iov_base = arr,
-                        .iov_len = arr.len,
+                        .base = arr,
+                        .len = arr.len,
                     };
                 },
             }
@@ -609,15 +609,15 @@ fn UDPSendMsg(comptime xev: type) type {
             switch (s.op.send.buf) {
                 .slice => |v| {
                     s.op.send.iov[0] = .{
-                        .iov_base = v.ptr,
-                        .iov_len = v.len,
+                        .base = v.ptr,
+                        .len = v.len,
                     };
                 },
 
                 .array => |*arr| {
                     s.op.send.iov[0] = .{
-                        .iov_base = &arr.array,
-                        .iov_len = arr.len,
+                        .base = &arr.array,
+                        .len = arr.len,
                     };
                 },
             }


### PR DESCRIPTION
this PR allows libxev to compile with zig version 0.13. I'm a little unsure about the one instance where on my machine I had to use `.{ .cwd_relative = file }` rather than `b.path(file)` for the pkg-config `.pc` file install step.