### PR TITLE
Update to latest Zig Nightly

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -344,5 +344,5 @@ fn exampleTargets(
 
 /// Path to the directory with the build.zig.
 fn thisDir() []const u8 {
-    return std.fs.path.dirname(@src().file) orelse unreachable;
+    return std.fs.path.dirname(@src().file) orelse "./";
 }

--- a/src/backend/epoll.zig
+++ b/src/backend/epoll.zig
@@ -150,8 +150,8 @@ pub const Loop = struct {
 
         // Calculate all the values, being careful about overflows in order
         // to just return the maximum value.
-        const sec = std.math.mul(isize, self.cached_now.tv_sec, std.time.ms_per_s) catch return max;
-        const nsec = @divFloor(self.cached_now.tv_nsec, std.time.ns_per_ms);
+        const sec = std.math.mul(isize, self.cached_now.sec, std.time.ms_per_s) catch return max;
+        const nsec = @divFloor(self.cached_now.nsec, std.time.ns_per_ms);
         return std.math.lossyCast(i64, sec +| nsec);
     }
 
@@ -229,8 +229,8 @@ pub const Loop = struct {
         // There are lots of failure scenarios here in math. If we see any
         // of them we just use the maximum value.
         const max: posix.timespec = .{
-            .tv_sec = std.math.maxInt(isize),
-            .tv_nsec = std.math.maxInt(isize),
+            .sec = std.math.maxInt(isize),
+            .nsec = std.math.maxInt(isize),
         };
 
         const next_s = std.math.cast(isize, next_ms / std.time.ms_per_s) orelse
@@ -241,9 +241,9 @@ pub const Loop = struct {
         ) orelse return max;
 
         return .{
-            .tv_sec = std.math.add(isize, self.cached_now.tv_sec, next_s) catch
+            .sec = std.math.add(isize, self.cached_now.sec, next_s) catch
                 return max,
-            .tv_nsec = std.math.add(isize, self.cached_now.tv_nsec, next_ns) catch
+            .nsec = std.math.add(isize, self.cached_now.nsec, next_ns) catch
                 return max,
         };
     }
@@ -352,10 +352,10 @@ pub const Loop = struct {
                 const t = self.timers.peek() orelse break :timeout 100;
 
                 // Determine the time in milliseconds.
-                const ms_now = @as(u64, @intCast(self.cached_now.tv_sec)) * std.time.ms_per_s +
-                    @as(u64, @intCast(self.cached_now.tv_nsec)) / std.time.ns_per_ms;
-                const ms_next = @as(u64, @intCast(t.next.tv_sec)) * std.time.ms_per_s +
-                    @as(u64, @intCast(t.next.tv_nsec)) / std.time.ns_per_ms;
+                const ms_now = @as(u64, @intCast(self.cached_now.sec)) * std.time.ms_per_s +
+                    @as(u64, @intCast(self.cached_now.nsec)) / std.time.ns_per_ms;
+                const ms_next = @as(u64, @intCast(t.next.sec)) * std.time.ms_per_s +
+                    @as(u64, @intCast(t.next.nsec)) / std.time.ns_per_ms;
                 break :timeout @as(i32, @intCast(ms_next -| ms_now));
             };
 
@@ -1169,16 +1169,16 @@ pub const Operation = union(OperationType) {
         /// any software is running in 584 years waiting on this timer...
         /// shame on me I guess... but I'll be dead.
         fn ns(self: *const Timer) u64 {
-            assert(self.next.tv_sec >= 0);
-            assert(self.next.tv_nsec >= 0);
+            assert(self.next.sec >= 0);
+            assert(self.next.nsec >= 0);
 
             const max = std.math.maxInt(u64);
             const s_ns = std.math.mul(
                 u64,
-                @as(u64, @intCast(self.next.tv_sec)),
+                @as(u64, @intCast(self.next.sec)),
                 std.time.ns_per_s,
             ) catch return max;
-            return std.math.add(u64, s_ns, @as(u64, @intCast(self.next.tv_nsec))) catch
+            return std.math.add(u64, s_ns, @as(u64, @intCast(self.next.nsec))) catch
                 return max;
         }
     };

--- a/src/backend/io_uring.zig
+++ b/src/backend/io_uring.zig
@@ -89,8 +89,8 @@ pub const Loop = struct {
 
         // Calculate all the values, being careful about overflows in order
         // to just return the maximum value.
-        const sec = std.math.mul(isize, self.cached_now.tv_sec, std.time.ms_per_s) catch return max;
-        const nsec = @divFloor(self.cached_now.tv_nsec, std.time.ns_per_ms);
+        const sec = std.math.mul(isize, self.cached_now.sec, std.time.ms_per_s) catch return max;
+        const nsec = @divFloor(self.cached_now.nsec, std.time.ns_per_ms);
         return std.math.lossyCast(i64, sec +| nsec);
     }
 
@@ -290,8 +290,8 @@ pub const Loop = struct {
         // There are lots of failure scenarios here in math. If we see any
         // of them we just use the maximum value.
         const max: linux.kernel_timespec = .{
-            .tv_sec = std.math.maxInt(isize),
-            .tv_nsec = std.math.maxInt(isize),
+            .sec = std.math.maxInt(isize),
+            .nsec = std.math.maxInt(isize),
         };
 
         const next_s = std.math.cast(isize, next_ms / std.time.ms_per_s) orelse
@@ -304,9 +304,9 @@ pub const Loop = struct {
         if (self.flags.now_outdated) self.update_now();
 
         return .{
-            .tv_sec = std.math.add(isize, self.cached_now.tv_sec, next_s) catch
+            .sec = std.math.add(isize, self.cached_now.sec, next_s) catch
                 return max,
-            .tv_nsec = std.math.add(isize, self.cached_now.tv_nsec, next_ns) catch
+            .nsec = std.math.add(isize, self.cached_now.nsec, next_ns) catch
                 return max,
         };
     }

--- a/src/build/ScdocStep.zig
+++ b/src/build/ScdocStep.zig
@@ -50,14 +50,9 @@ fn make(step: *std.Build.Step, _: std.Build.Step.MakeOptions) !void {
     const self: *ScdocStep = @fieldParentPtr("step", step);
 
     // Create our cache path
-    // TODO(mitchellh): ideally this would be pure zig
     {
-        const command = try std.fmt.allocPrint(
-            self.builder.allocator,
-            "rm -f {[path]s}/* && mkdir -p {[path]s}",
-            .{ .path = self.out_path },
-        );
-        _ = self.builder.run(&[_][]const u8{ "sh", "-c", command });
+        try std.fs.cwd().deleteTree(self.out_path);
+        try std.fs.cwd().makePath(self.out_path);
     }
 
     // Find all our man pages which are in our src path ending with ".scd".

--- a/src/build/ScdocStep.zig
+++ b/src/build/ScdocStep.zig
@@ -46,7 +46,7 @@ pub fn init(builder: *Build) ScdocStep {
     };
 }
 
-fn make(step: *std.Build.Step, _: std.Progress.Node) !void {
+fn make(step: *std.Build.Step, _: std.Build.Step.MakeOptions) !void {
     const self: *ScdocStep = @fieldParentPtr("step", step);
 
     // Create our cache path
@@ -126,7 +126,7 @@ const InstallStep = struct {
         };
     }
 
-    fn make(step: *Step, progress: std.Progress.Node) !void {
+    fn make(step: *Step, opts: Step.MakeOptions) !void {
         const self: *InstallStep = @fieldParentPtr("step", step);
 
         // Get our absolute output path
@@ -157,7 +157,7 @@ const InstallStep = struct {
                 .{ .cwd_relative = src },
                 output,
             );
-            try fileStep.step.make(progress);
+            try fileStep.step.make(opts);
         }
     }
 };

--- a/src/linux/timerfd.zig
+++ b/src/linux/timerfd.zig
@@ -15,7 +15,7 @@ pub const Timerfd = struct {
 
     /// timerfd_create
     pub fn init(clock: Clock, flags: linux.TFD) !Timerfd {
-        const res = linux.timerfd_create(@intFromEnum(clock), flags);
+        const res = linux.timerfd_create(@enumFromInt(@intFromEnum(clock)), flags);
         return switch (posix.errno(res)) {
             .SUCCESS => .{ .fd = @as(i32, @intCast(res)) },
             else => error.UnknownError,


### PR DESCRIPTION
Currently errors on build/test due to changes in build and standard library in Zig nightly. Updated to work on `Zig 0.14.0-dev.839+a931bfada`, and also completed a small `TODO` to change man pages cache directory creation to pure Zig.

Tested both man page generation output in `.zig-cache` and passed all `zig build test` tests on x86_64 Linux.