### PR TITLE
io_uring: handle INTR error from write

### DIFF
--- a/src/backend/io_uring.zig
+++ b/src/backend/io_uring.zig
@@ -744,6 +744,8 @@ pub const Completion = struct {
                     @intCast(res)
                 else switch (@as(posix.E, @enumFromInt(-res))) {
                     .CANCELED => error.Canceled,
+                    // If a write is interrupted, we retry it automatically.
+                    .INTR => return .rearm,
                     else => |errno| posix.unexpectedErrno(errno),
                 },
             },


### PR DESCRIPTION
It is possible to get an EINTR error from io_uring when copying cqes.
xev already handles EINTR automatically when it occurs during
io_uring_enter, but doesn't handle it if an individual cqe copy has this
error.

Add error.SignalInterrupt to the WriteError enum so that callers may
rearm their writes when encountering this error, if they desire.
