### PR TITLE
backend/kqueue: fix empty udata crash

### DIFF
--- a/src/backend/kqueue.zig
+++ b/src/backend/kqueue.zig
@@ -206,10 +206,14 @@ pub const Loop = struct {
             // event list to zero length) because it was leading to
             // memory corruption we need to investigate.
             for (events[0..completed]) |ev| {
-                const c: *Completion = @ptrFromInt(@as(usize, @intCast(ev.udata)));
+                // Zero udata values are internal events that we do nothing
+                // on such as the mach port wakeup.
+                if (ev.udata == 0) continue;
 
                 // We handle deletions separately.
                 if (ev.flags & posix.system.EV_DELETE != 0) continue;
+
+                const c: *Completion = @ptrFromInt(@as(usize, @intCast(ev.udata)));
 
                 // If EV_ERROR is set, then submission failed for this
                 // completion. We get the syscall errorcode from data and


### PR DESCRIPTION
On certain occasions, internal kqueue events are dispatched with an empty udata field. This causes a crash when trying to access the udata field in the event handler.

This patch adds a check to ensure that the udata field is not empty before accessing it just like in the other events consumer.