### PR TITLE
Check if the threadpool can actually be used

### DIFF
--- a/src/backend/epoll.zig
+++ b/src/backend/epoll.zig
@@ -1358,7 +1358,7 @@ test "Completion size" {
     const testing = std.testing;
 
     // Just so we are aware when we change the size
-    try testing.expectEqual(@as(usize, 200), @sizeOf(Completion));
+    try testing.expectEqual(@as(usize, 208), @sizeOf(Completion));
 }
 
 test "epoll: default completion" {

--- a/src/watcher/file.zig
+++ b/src/watcher/file.zig
@@ -115,11 +115,13 @@ pub fn File(comptime xev: type) type {
                         => {},
 
                         .epoll => {
-                            c.flags.threadpool = true;
+                            if (loop.thread_pool != null)
+                                c.flags.threadpool = true;
                         },
 
                         .kqueue => {
-                            c.flags.threadpool = true;
+                            if (loop.thread_pool != null)
+                                c.flags.threadpool = true;
                         },
                     }
 
@@ -217,7 +219,7 @@ pub fn File(comptime xev: type) type {
                 r: Self.WriteError!usize,
             ) xev.CallbackAction,
         ) void {
-            self.pwrite_init(c, buf, offset);
+            self.pwrite_init(c, buf, offset, loop);
             c.userdata = userdata;
             c.callback = (struct {
                 fn callback(
@@ -258,6 +260,7 @@ pub fn File(comptime xev: type) type {
             c: *xev.Completion,
             buf: xev.WriteBuffer,
             offset: u64,
+            loop: *xev.Loop,
         ) void {
             switch (buf) {
                 inline .slice, .array => {
@@ -279,11 +282,13 @@ pub fn File(comptime xev: type) type {
                         => {},
 
                         .epoll => {
-                            c.flags.threadpool = true;
+                            if (loop.thread_pool != null)
+                                c.flags.threadpool = true;
                         },
 
                         .kqueue => {
-                            c.flags.threadpool = true;
+                            if (loop.thread_pool != null)
+                                c.flags.threadpool = true;
                         },
                     }
                 },

--- a/src/watcher/tcp.zig
+++ b/src/watcher/tcp.zig
@@ -4,6 +4,7 @@ const assert = std.debug.assert;
 const posix = std.posix;
 const stream = @import("stream.zig");
 const common = @import("common.zig");
+const ThreadPool = @import("../ThreadPool.zig");
 
 /// TCP client and server.
 ///
@@ -233,8 +234,8 @@ pub fn TCP(comptime xev: type) type {
             if (xev.backend == .wasi_poll) return error.SkipZigTest;
 
             const testing = std.testing;
-
-            var loop = try xev.Loop.init(.{});
+            var thr = ThreadPool.init(.{});
+            var loop = try xev.Loop.init(.{ .thread_pool = @ptrCast(&thr) });
             defer loop.deinit();
 
             // Choose random available port (Zig #14907)


### PR DESCRIPTION
At the moment the current main branch fails the CI because the testcases for the epoll/kqueue backend do not have the threadpool enabled, while most of the code tries to use it anyway. 

This PR adds a check so that completions may be sent to the threadpool only if the loop has actually one specified.