### PR TITLE
File: fix FdType for windows targets

### DIFF
--- a/src/watcher/file.zig
+++ b/src/watcher/file.zig
@@ -27,7 +27,7 @@ const stream = @import("stream.zig");
 pub fn File(comptime xev: type) type {
     return struct {
         const Self = @This();
-        const FdType = if (xev.backend == .iocp) std.windows.HANDLE else posix.socket_t;
+        const FdType = if (xev.backend == .iocp) std.os.windows.HANDLE else posix.socket_t;
 
         /// The underlying file
         fd: FdType,


### PR DESCRIPTION
The namespace for Windows in zig 0.13.0 is `std.os.windows`. Fix FdType
to point to the correct path for windows.HANDLE
