### PR TITLE
stream: add poll function for read polling

### DIFF
--- a/src/watcher/tcp.zig
+++ b/src/watcher/tcp.zig
@@ -23,6 +23,7 @@ pub fn TCP(comptime xev: type) type {
 
         pub usingnamespace stream.Stream(xev, Self, .{
             .close = true,
+            .poll = true,
             .read = .recv,
             .write = .send,
         });

--- a/src/watcher/udp.zig
+++ b/src/watcher/udp.zig
@@ -45,6 +45,7 @@ fn UDPSendto(comptime xev: type) type {
 
         pub usingnamespace stream.Stream(xev, Self, .{
             .close = true,
+            .poll = true,
             .read = .none,
             .write = .none,
         });
@@ -226,6 +227,7 @@ fn UDPSendtoIOCP(comptime xev: type) type {
 
         pub usingnamespace stream.Stream(xev, Self, .{
             .close = true,
+            .poll = false,
             .read = .none,
             .write = .none,
         });
@@ -424,6 +426,7 @@ fn UDPSendMsg(comptime xev: type) type {
 
         pub usingnamespace stream.Stream(xev, Self, .{
             .close = true,
+            .poll = true,
             .read = .none,
             .write = .none,
         });


### PR DESCRIPTION
This adds a stream `poll` function that works with files, sockets, and other fd-based types to allow for polling. This commit only implements read polling, but write polling will be added in a future commit.

Notably, this is useful because polling never requires a threadpool, so if the caller wanted to handle when they read on their own, they can use this instead of `read()` (which -- on certain backends -- does require a threadpool).

io_uring and epoll have native `poll` event types so this is easy. For kqueue, I had to make a special case for empty read buffers to avoid reading and just triggering the callback as readable.

iocp (Windows) doesn't implement this functionality but I suspect it'd be relatively simple to add. cc @Corendos 