### PR TITLE
`xev.Dynamic` to choose between multiple backends at runtime

### DIFF
--- a/src/backend/epoll.zig
+++ b/src/backend/epoll.zig
@@ -114,6 +114,12 @@ pub const Loop = struct {
         self.flags.stopped = true;
     }
 
+    /// Returns true if the loop is stopped. This may mean there
+    /// are still pending completions to be processed.
+    pub fn stopped(self: *Loop) bool {
+        return self.flags.stopped;
+    }
+
     /// Add a completion to the loop.
     pub fn add(self: *Loop, completion: *Completion) void {
         switch (completion.flags.state) {

--- a/src/backend/epoll.zig
+++ b/src/backend/epoll.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const assert = std.debug.assert;
 const linux = std.os.linux;
 const posix = std.posix;
@@ -8,6 +9,11 @@ const heap = @import("../heap.zig");
 const main = @import("../main.zig");
 const xev = main.Epoll;
 const ThreadPool = main.ThreadPool;
+
+/// True if epoll is available on this platform.
+pub fn available() bool {
+    return builtin.os.tag == .linux;
+}
 
 /// Epoll backend.
 ///

--- a/src/backend/io_uring.zig
+++ b/src/backend/io_uring.zig
@@ -89,6 +89,12 @@ pub const Loop = struct {
         self.flags.stopped = true;
     }
 
+    /// Returns true if the loop is stopped. This may mean there
+    /// are still pending completions to be processed.
+    pub fn stopped(self: *Loop) bool {
+        return self.flags.stopped;
+    }
+
     /// Returns the "loop" time in milliseconds. The loop time is updated
     /// once per loop tick, before IO polling occurs. It remains constant
     /// throughout callback execution.

--- a/src/backend/iocp.zig
+++ b/src/backend/iocp.zig
@@ -1,5 +1,6 @@
 //! Backend to use win32 IOCP.
 const std = @import("std");
+const builtin = @import("builtin");
 const assert = std.debug.assert;
 const windows = @import("../windows.zig");
 const queue = @import("../queue.zig");
@@ -8,6 +9,14 @@ const xev = @import("../main.zig").IOCP;
 const posix = std.posix;
 
 const log = std.log.scoped(.libxev_iocp);
+
+/// True if this backend is available on this platform.
+pub fn available() bool {
+    return switch (builtin.os.tag) {
+        .windows => true,
+        else => false,
+    };
+}
 
 pub const Loop = struct {
     const TimerHeap = heap.Intrusive(Timer, void, Timer.less);

--- a/src/backend/iocp.zig
+++ b/src/backend/iocp.zig
@@ -98,6 +98,12 @@ pub const Loop = struct {
         self.flags.stopped = true;
     }
 
+    /// Returns true if the loop is stopped. This may mean there
+    /// are still pending completions to be processed.
+    pub fn stopped(self: *Loop) bool {
+        return self.flags.stopped;
+    }
+
     /// Add a completion to the loop. The completion is not started until the loop is run (`run`) or
     /// an explicit submission request is made (`submit`).
     pub fn add(self: *Loop, completion: *Completion) void {

--- a/src/backend/kqueue.zig
+++ b/src/backend/kqueue.zig
@@ -13,6 +13,19 @@ const ThreadPool = main.ThreadPool;
 
 const log = std.log.scoped(.libxev_kqueue);
 
+/// True if this backend is available on this platform.
+pub fn available() bool {
+    return switch (builtin.os.tag) {
+        .ios, .macos => true,
+
+        // Technically other BSDs support kqueue but our implementation
+        // below hard requires mach ports currently. That's not a fundamental
+        // requirement but until someone makes this implementation work
+        // on other BSDs we'll just say it isn't available.
+        else => false,
+    };
+}
+
 pub const Loop = struct {
     const TimerHeap = heap.Intrusive(Timer, void, Timer.less);
     const TaskCompletionQueue = queue_mpsc.Intrusive(Completion);

--- a/src/backend/kqueue.zig
+++ b/src/backend/kqueue.zig
@@ -126,6 +126,12 @@ pub const Loop = struct {
         self.flags.stopped = true;
     }
 
+    /// Returns true if the loop is stopped. This may mean there
+    /// are still pending completions to be processed.
+    pub fn stopped(self: *Loop) bool {
+        return self.flags.stopped;
+    }
+
     /// Add a completion to the loop. The completion is not started until
     /// the loop is run (`run`, `tick`) or an explicit submission request
     /// is made (`submit`).

--- a/src/backend/wasi_poll.zig
+++ b/src/backend/wasi_poll.zig
@@ -7,6 +7,11 @@ const queue = @import("../queue.zig");
 const heap = @import("../heap.zig");
 const xev = @import("../main.zig").WasiPoll;
 
+/// True if this backend is available on this platform.
+pub fn available() bool {
+    return builtin.os.tag == .wasi;
+}
+
 pub const Loop = struct {
     pub const threaded = std.Target.wasm.featureSetHas(builtin.cpu.features, .atomics);
     const TimerHeap = heap.Intrusive(Timer, void, Timer.less);

--- a/src/backend/wasi_poll.zig
+++ b/src/backend/wasi_poll.zig
@@ -81,6 +81,12 @@ pub const Loop = struct {
         self.flags.stopped = true;
     }
 
+    /// Returns true if the loop is stopped. This may mean there
+    /// are still pending completions to be processed.
+    pub fn stopped(self: *Loop) bool {
+        return self.flags.stopped;
+    }
+
     /// Add a completion to the loop. This doesn't DO anything except queue
     /// the completion. Any configuration errors will be exposed via the
     /// callback on the next loop tick.

--- a/src/bench/async1.zig
+++ b/src/bench/async1.zig
@@ -3,6 +3,7 @@ const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 const Instant = std.time.Instant;
 const xev = @import("xev");
+//const xev = @import("xev").Dynamic;
 
 pub const std_options: std.Options = .{
     .log_level = .info,
@@ -16,6 +17,7 @@ pub fn main() !void {
 }
 
 pub fn run(comptime thread_count: comptime_int) !void {
+    if (comptime xev.dynamic) try xev.detect();
     var loop = try xev.Loop.init(.{});
     defer loop.deinit();
 

--- a/src/bench/async_pummel_1.zig
+++ b/src/bench/async_pummel_1.zig
@@ -3,6 +3,7 @@ const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 const Instant = std.time.Instant;
 const xev = @import("xev");
+//const xev = @import("xev").Dynamic;
 
 pub const std_options: std.Options = .{
     .log_level = .info,
@@ -20,6 +21,7 @@ pub fn run(comptime thread_count: comptime_int) !void {
     defer thread_pool.deinit();
     defer thread_pool.shutdown();
 
+    if (xev.dynamic) try xev.detect();
     var loop = try xev.Loop.init(.{
         .entries = std.math.pow(u13, 2, 12),
         .thread_pool = &thread_pool,

--- a/src/bench/million-timers.zig
+++ b/src/bench/million-timers.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const Instant = std.time.Instant;
 const xev = @import("xev");
+//const xev = @import("xev").Dynamic;
 
 pub const NUM_TIMERS: usize = 10 * 1000 * 1000;
 
@@ -9,6 +10,7 @@ pub fn main() !void {
     defer thread_pool.deinit();
     defer thread_pool.shutdown();
 
+    if (xev.dynamic) try xev.detect();
     var loop = try xev.Loop.init(.{
         .entries = std.math.pow(u13, 2, 12),
         .thread_pool = &thread_pool,

--- a/src/bench/ping-pongs.zig
+++ b/src/bench/ping-pongs.zig
@@ -124,7 +124,7 @@ const Client = struct {
         c: *xev.Completion,
         s: xev.TCP,
         b: xev.WriteBuffer,
-        r: xev.TCP.WriteError!usize,
+        r: xev.WriteError!usize,
     ) xev.CallbackAction {
         _ = r catch unreachable;
         _ = l;
@@ -142,7 +142,7 @@ const Client = struct {
         c: *xev.Completion,
         socket: xev.TCP,
         buf: xev.ReadBuffer,
-        r: xev.TCP.ReadError!usize,
+        r: xev.ReadError!usize,
     ) xev.CallbackAction {
         const self = self_.?;
         const n = r catch unreachable;
@@ -275,7 +275,7 @@ const Server = struct {
         c: *xev.Completion,
         socket: xev.TCP,
         buf: xev.ReadBuffer,
-        r: xev.TCP.ReadError!usize,
+        r: xev.ReadError!usize,
     ) xev.CallbackAction {
         const self = self_.?;
         const n = r catch |err| switch (err) {
@@ -309,7 +309,7 @@ const Server = struct {
         c: *xev.Completion,
         s: xev.TCP,
         buf: xev.WriteBuffer,
-        r: xev.TCP.WriteError!usize,
+        r: xev.WriteError!usize,
     ) xev.CallbackAction {
         _ = l;
         _ = s;

--- a/src/bench/ping-pongs.zig
+++ b/src/bench/ping-pongs.zig
@@ -103,7 +103,7 @@ const Client = struct {
         l: *xev.Loop,
         c: *xev.Completion,
         socket: xev.TCP,
-        r: xev.TCP.ConnectError!void,
+        r: xev.ConnectError!void,
     ) xev.CallbackAction {
         _ = r catch unreachable;
 
@@ -177,7 +177,7 @@ const Client = struct {
         l: *xev.Loop,
         c: *xev.Completion,
         socket: xev.TCP,
-        r: xev.TCP.ShutdownError!void,
+        r: xev.ShutdownError!void,
     ) xev.CallbackAction {
         _ = r catch {};
 
@@ -191,7 +191,7 @@ const Client = struct {
         l: *xev.Loop,
         c: *xev.Completion,
         socket: xev.TCP,
-        r: xev.TCP.CloseError!void,
+        r: xev.CloseError!void,
     ) xev.CallbackAction {
         _ = l;
         _ = socket;
@@ -255,7 +255,7 @@ const Server = struct {
         self_: ?*Server,
         l: *xev.Loop,
         c: *xev.Completion,
-        r: xev.TCP.AcceptError!xev.TCP,
+        r: xev.AcceptError!xev.TCP,
     ) xev.CallbackAction {
         const self = self_.?;
 
@@ -331,7 +331,7 @@ const Server = struct {
         l: *xev.Loop,
         c: *xev.Completion,
         s: xev.TCP,
-        r: xev.TCP.ShutdownError!void,
+        r: xev.ShutdownError!void,
     ) xev.CallbackAction {
         _ = r catch {};
 
@@ -345,7 +345,7 @@ const Server = struct {
         l: *xev.Loop,
         c: *xev.Completion,
         socket: xev.TCP,
-        r: xev.TCP.CloseError!void,
+        r: xev.CloseError!void,
     ) xev.CallbackAction {
         _ = l;
         _ = r catch unreachable;

--- a/src/bench/ping-pongs.zig
+++ b/src/bench/ping-pongs.zig
@@ -3,6 +3,7 @@ const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 const Instant = std.time.Instant;
 const xev = @import("xev");
+//const xev = @import("xev").Dynamic;
 
 pub const std_options: std.Options = .{
     .log_level = .info,
@@ -13,6 +14,7 @@ pub fn main() !void {
     defer thread_pool.deinit();
     defer thread_pool.shutdown();
 
+    if (xev.dynamic) try xev.detect();
     var loop = try xev.Loop.init(.{
         .entries = std.math.pow(u13, 2, 12),
         .thread_pool = &thread_pool,

--- a/src/bench/ping-udp1.zig
+++ b/src/bench/ping-udp1.zig
@@ -4,6 +4,7 @@ const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 const Instant = std.time.Instant;
 const xev = @import("xev");
+//const xev = @import("xev").Dynamic;
 
 pub const std_options: std.Options = .{
     .log_level = .info,
@@ -18,6 +19,7 @@ pub fn run(comptime count: comptime_int) !void {
     defer thread_pool.deinit();
     defer thread_pool.shutdown();
 
+    if (xev.dynamic) try xev.detect();
     var loop = try xev.Loop.init(.{
         .entries = std.math.pow(u13, 2, 12),
         .thread_pool = &thread_pool,

--- a/src/bench/ping-udp1.zig
+++ b/src/bench/ping-udp1.zig
@@ -169,7 +169,7 @@ const Pinger = struct {
         _: *xev.Loop,
         _: *xev.Completion,
         _: xev.UDP,
-        r: xev.UDP.CloseError!void,
+        r: xev.CloseError!void,
     ) xev.CallbackAction {
         _ = r catch unreachable;
         return .disarm;

--- a/src/bench/ping-udp1.zig
+++ b/src/bench/ping-udp1.zig
@@ -109,7 +109,7 @@ const Pinger = struct {
         _: std.net.Address,
         socket: xev.UDP,
         buf: xev.ReadBuffer,
-        r: xev.UDP.ReadError!usize,
+        r: xev.ReadError!usize,
     ) xev.CallbackAction {
         _ = c;
         _ = socket;
@@ -149,7 +149,7 @@ const Pinger = struct {
         _: *xev.UDP.State,
         _: xev.UDP,
         _: xev.WriteBuffer,
-        r: xev.UDP.WriteError!usize,
+        r: xev.WriteError!usize,
     ) xev.CallbackAction {
         const self = self_.?;
 

--- a/src/bench/udp_pummel_1v1.zig
+++ b/src/bench/udp_pummel_1v1.zig
@@ -96,7 +96,7 @@ const Sender = struct {
         _: *xev.UDP.State,
         _: xev.UDP,
         _: xev.WriteBuffer,
-        r: xev.UDP.WriteError!usize,
+        r: xev.WriteError!usize,
     ) xev.CallbackAction {
         _ = r catch unreachable;
 
@@ -126,7 +126,7 @@ const Receiver = struct {
         _: std.net.Address,
         _: xev.UDP,
         b: xev.ReadBuffer,
-        r: xev.UDP.ReadError!usize,
+        r: xev.ReadError!usize,
     ) xev.CallbackAction {
         const n = r catch |err| {
             switch (err) {

--- a/src/bench/udp_pummel_1v1.zig
+++ b/src/bench/udp_pummel_1v1.zig
@@ -3,6 +3,7 @@ const assert = std.debug.assert;
 const Allocator = std.mem.Allocator;
 const Instant = std.time.Instant;
 const xev = @import("xev");
+//const xev = @import("xev").Dynamic;
 
 const EXPECTED = "RANG TANG DING DONG I AM THE JAPANESE SANDMAN";
 
@@ -27,6 +28,7 @@ pub fn run(comptime n_senders: comptime_int, comptime n_receivers: comptime_int)
     defer thread_pool.deinit();
     defer thread_pool.shutdown();
 
+    if (xev.dynamic) try xev.detect();
     var loop = try xev.Loop.init(.{
         .entries = std.math.pow(u13, 2, 12),
         .thread_pool = &thread_pool,

--- a/src/dynamic.zig
+++ b/src/dynamic.zig
@@ -134,6 +134,15 @@ pub fn Xev(comptime bes: []const AllBackend) type {
                 }
             }
 
+            pub fn stopped(self: *Loop) bool {
+                return switch (backend) {
+                    inline else => |tag| @field(
+                        self.backend,
+                        @tagName(tag),
+                    ).stopped(),
+                };
+            }
+
             pub fn run(self: *Loop, mode: RunMode) !void {
                 switch (backend) {
                     inline else => |tag| try @field(
@@ -191,6 +200,7 @@ pub fn Xev(comptime bes: []const AllBackend) type {
             defer l.deinit();
             try l.run(.until_done);
             l.stop();
+            try std.testing.expect(l.stopped());
         }
     };
 }

--- a/src/dynamic.zig
+++ b/src/dynamic.zig
@@ -78,6 +78,7 @@ pub fn Xev(comptime bes: []const AllBackend) type {
         pub const Process = @import("watcher/process.zig").Process(Dynamic);
         pub const Stream = @import("watcher/stream.zig").GenericStream(Dynamic);
         pub const Timer = @import("watcher/timer.zig").Timer(Dynamic);
+        pub const TCP = @import("watcher/tcp.zig").TCP(Dynamic);
 
         /// The backend that is in use.
         pub var backend: Backend = subset(bes[bes.len - 1]);

--- a/src/dynamic.zig
+++ b/src/dynamic.zig
@@ -79,6 +79,7 @@ pub fn Xev(comptime bes: []const AllBackend) type {
         pub const Stream = @import("watcher/stream.zig").GenericStream(Dynamic);
         pub const Timer = @import("watcher/timer.zig").Timer(Dynamic);
         pub const TCP = @import("watcher/tcp.zig").TCP(Dynamic);
+        pub const UDP = @import("watcher/udp.zig").UDP(Dynamic);
 
         /// The backend that is in use.
         pub var backend: Backend = subset(bes[bes.len - 1]);

--- a/src/dynamic.zig
+++ b/src/dynamic.zig
@@ -2,7 +2,8 @@ const dynamicpkg = @This();
 const std = @import("std");
 const builtin = @import("builtin");
 const posix = std.posix;
-const AllBackend = @import("main.zig").Backend;
+const main = @import("main.zig");
+const AllBackend = main.Backend;
 const looppkg = @import("loop.zig");
 
 /// Creates the Xev API based on a set of backend types that allows
@@ -49,6 +50,11 @@ pub fn Xev(comptime bes: []const AllBackend) type {
         /// Backend becomes the subset of the full xev.Backend that
         /// is available to this dynamic API.
         pub const Backend = EnumSubset(AllBackend, bes);
+
+        /// Forward some global types so that users can replace
+        /// @import("xev") with the dynamic package and everything
+        /// works.
+        pub const ThreadPool = main.ThreadPool;
 
         /// The shared structures
         pub const Options = looppkg.Options;

--- a/src/dynamic.zig
+++ b/src/dynamic.zig
@@ -1,0 +1,196 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const AllBackend = @import("main.zig").Backend;
+const loop = @import("loop.zig");
+
+/// Creates the Xev API based on a set of backend types that allows
+/// for dynamic choice between the various candidate backends (assuming
+/// they're available). For example, on Linux, this allows a consumer to
+/// choose between io_uring and epoll, or for automatic fallback to epoll
+/// to occur.
+///
+/// If only one backend is given, the returned type is equivalent to
+/// the static API with no runtime conditional logic, so there is no downside
+/// to always using the dynamic choice variant if you wish to support
+/// dynamic choice.
+///
+/// The goal of this API is to match the static Xev() (in main.zig)
+/// API as closely as possible. It can't be exact since this is an abstraction
+/// and therefore must be limited to the least common denominator of all
+/// backends.
+///
+/// Since the static Xev API exposes types that can be initialized on their
+/// own (i.e. xev.Async.init()), this API does the same. Since we need to
+/// know the backend to use, this uses a global variable. The backend to use
+/// defaults to the first candidate backend and DOES NOT test that it is
+/// available. The API user should call `detect()` to set the backend to
+/// the first available backend.
+///
+/// Additionally, a caller can manually set the backend to use, but this
+/// must be done before initializing any other types.
+pub fn Xev(comptime bes: []const AllBackend) type {
+    if (bes.len == 0) @compileError("no backends provided");
+
+    // Ensure that if we only have one candidate that we have no
+    // overhead to use the dynamic API.
+    if (bes.len == 1) return bes[0].Api();
+
+    return struct {
+        const Dynamic = @This();
+
+        /// Backend becomes the subset of the full xev.Backend that
+        /// is available to this dynamic API.
+        pub const Backend = EnumSubset(AllBackend, bes);
+
+        /// The shared structures
+        pub const Options = loop.Options;
+        pub const RunMode = loop.RunMode;
+        pub const CallbackAction = loop.CallbackAction;
+        pub const CompletionState = loop.CompletionState;
+        pub const Completion = Union(bes, "Completion");
+
+        /// The backend that is in use.
+        var backend: Backend = subset(bes[bes.len - 1]);
+
+        /// Detect the preferred backend based on the system and set it
+        /// for use. "Preferred" is the first available (API exists) candidate
+        /// backend in the list.
+        pub fn detect() error{NoAvailableBackends}!void {
+            inline for (bes) |be| {
+                if (be.Api().available()) {
+                    backend = subset(be);
+                    return;
+                }
+            }
+
+            return error.NoAvailableBackends;
+        }
+
+        const LoopUnion = Union(bes, "Loop");
+        pub const Loop = struct {
+            backend: LoopUnion,
+
+            pub fn init(opts: Options) !Loop {
+                return .{ .backend = switch (backend) {
+                    inline else => |tag| backend: {
+                        const api = (comptime superset(tag)).Api();
+                        break :backend @unionInit(
+                            LoopUnion,
+                            @tagName(tag),
+                            try api.Loop.init(opts),
+                        );
+                    },
+                } };
+            }
+
+            pub fn deinit(self: *Loop) void {
+                switch (backend) {
+                    inline else => |tag| @field(
+                        self.backend,
+                        @tagName(tag),
+                    ).deinit(),
+                }
+            }
+
+            pub fn stop(self: *Loop) void {
+                switch (backend) {
+                    inline else => |tag| @field(
+                        self.backend,
+                        @tagName(tag),
+                    ).stop(),
+                }
+            }
+
+            pub fn run(self: *Loop, mode: RunMode) !void {
+                switch (backend) {
+                    inline else => |tag| try @field(
+                        self.backend,
+                        @tagName(tag),
+                    ).run(mode),
+                }
+            }
+        };
+
+        /// Helpers to convert between the subset/superset of backends.
+        fn subset(comptime be: AllBackend) Backend {
+            return @enumFromInt(@intFromEnum(be));
+        }
+
+        fn superset(comptime be: Backend) AllBackend {
+            return @enumFromInt(@intFromEnum(be));
+        }
+
+        test "detect" {
+            const testing = std.testing;
+            try detect();
+            inline for (bes) |be| {
+                if (@intFromEnum(be) == @intFromEnum(backend)) {
+                    try testing.expect(be.Api().available());
+                    break;
+                }
+            } else try testing.expect(false);
+        }
+
+        test "loop basics" {
+            try detect();
+            var l = try Loop.init(.{});
+            defer l.deinit();
+            try l.run(.until_done);
+            l.stop();
+        }
+    };
+}
+
+/// Create an exhaustive enum that is a subset of another enum.
+/// Preserves the same backing type and integer values for the
+/// subset making it easy to convert between the two.
+fn EnumSubset(comptime T: type, comptime values: []const T) type {
+    var fields: [values.len]std.builtin.Type.EnumField = undefined;
+    for (values, 0..) |value, i| fields[i] = .{
+        .name = @tagName(value),
+        .value = @intFromEnum(value),
+    };
+
+    return @Type(.{ .Enum = .{
+        .tag_type = @typeInfo(T).Enum.tag_type,
+        .fields = &fields,
+        .decls = &.{},
+        .is_exhaustive = true,
+    } });
+}
+
+/// Creates a union type that can hold the implementation of a given
+/// backend by common field name. Example, for Async: Union(bes, "Async")
+/// produces:
+///
+///   union {
+///     io_uring: IO_Uring.Async,
+///     epoll: Epoll.Async,
+///     ...
+///   }
+///
+/// The union is untagged to save an extra bit of memory per
+/// instance since we have the active backend from the outer struct.
+fn Union(
+    comptime bes: []const AllBackend,
+    comptime field: []const u8,
+) type {
+    var fields: [bes.len]std.builtin.Type.UnionField = undefined;
+    for (bes, 0..) |be, i| {
+        const T = @field(be.Api(), field);
+        fields[i] = .{
+            .name = @tagName(be),
+            .type = T,
+            .alignment = @alignOf(T),
+        };
+    }
+
+    return @Type(.{
+        .Union = .{
+            .layout = .auto,
+            .tag_type = null,
+            .fields = &fields,
+            .decls = &.{},
+        },
+    });
+}

--- a/src/dynamic.zig
+++ b/src/dynamic.zig
@@ -164,11 +164,12 @@ pub fn Xev(comptime bes: []const AllBackend) type {
         }
 
         test {
-            _ = Async;
-            _ = File;
-            _ = Process;
-            _ = Stream;
-            _ = Timer;
+            @import("std").testing.refAllDecls(@This());
+        }
+
+        test "completion is zero-able" {
+            const c: Completion = .{};
+            _ = c;
         }
 
         test "detect" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -102,6 +102,9 @@ pub fn Xev(comptime be: Backend, comptime T: type) type {
         const Self = @This();
         const loop = @import("loop.zig");
 
+        /// This is used to detect a static vs dynamic API at comptime.
+        pub const dynamic = false;
+
         /// The backend that this is. This is supplied at comptime so
         /// it is up to the caller to say the right thing. This lets custom
         /// implementations also "quack" like an implementation.

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const builtin = @import("builtin");
-const dynamic = @import("dynamic.zig");
 
 /// The low-level IO interfaces using the recommended compile-time
 /// interface for the target system.
@@ -20,7 +19,8 @@ pub usingnamespace xev;
 /// a backend and then this needs to be passed to every high-level
 /// type such as Async, File, etc. so that they can use the correct
 /// backend that is coherent with the loop.
-pub const Dynamic = dynamic.Xev(Backend.candidates());
+pub const dynamic = DynamicXev(Backend.candidates());
+pub const DynamicXev = @import("dynamic.zig").Xev;
 
 /// System-specific interfaces. Note that they are always pub for
 /// all systems but if you reference them and force them to be analyzed
@@ -191,7 +191,7 @@ test {
     _ = @import("queue.zig");
     _ = @import("queue_mpsc.zig");
     _ = ThreadPool;
-    _ = Dynamic;
+    _ = dynamic;
 
     // Test the C API
     if (builtin.os.tag != .wasi) _ = @import("c_api.zig");

--- a/src/main.zig
+++ b/src/main.zig
@@ -19,7 +19,7 @@ pub usingnamespace xev;
 /// a backend and then this needs to be passed to every high-level
 /// type such as Async, File, etc. so that they can use the correct
 /// backend that is coherent with the loop.
-pub const dynamic = DynamicXev(Backend.candidates());
+pub const Dynamic = DynamicXev(Backend.candidates());
 pub const DynamicXev = @import("dynamic.zig").Xev;
 
 /// System-specific interfaces. Note that they are always pub for
@@ -191,7 +191,7 @@ test {
     _ = @import("queue.zig");
     _ = @import("queue_mpsc.zig");
     _ = ThreadPool;
-    _ = dynamic;
+    _ = Dynamic;
 
     // Test the C API
     if (builtin.os.tag != .wasi) _ = @import("c_api.zig");

--- a/src/main.zig
+++ b/src/main.zig
@@ -134,6 +134,11 @@ pub fn Xev(comptime be: Backend, comptime T: type) type {
         pub const WriteError = T.WriteError;
         pub const ReadError = T.ReadError;
 
+        /// Shared stream types
+        const SharedStream = stream.Shared(Self);
+        pub const WriteQueue = SharedStream.WriteQueue;
+        pub const WriteRequest = SharedStream.WriteRequest;
+
         /// The high-level helper interfaces that make it easier to perform
         /// common tasks. These may not work with all possible Loop implementations.
         pub const Async = @import("watcher/async.zig").Async(Self);

--- a/src/main.zig
+++ b/src/main.zig
@@ -136,6 +136,8 @@ pub fn Xev(comptime be: Backend, comptime T: type) type {
 
         /// Shared stream types
         const SharedStream = stream.Shared(Self);
+        pub const PollError = SharedStream.PollError;
+        pub const PollEvent = SharedStream.PollEvent;
         pub const WriteQueue = SharedStream.WriteQueue;
         pub const WriteRequest = SharedStream.WriteRequest;
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -35,15 +35,15 @@ pub const Backend = enum {
 
     /// Returns a recommend default backend from inspecting the system.
     pub fn default() Backend {
-        return @as(?Backend, switch (builtin.os.tag) {
+        return switch (builtin.os.tag) {
             .linux => .io_uring,
             .ios, .macos => .kqueue,
             .wasi => .wasi_poll,
             .windows => .iocp,
-            else => null,
-        }) orelse {
-            @compileLog(builtin.os);
-            @compileError("no default backend for this target");
+            else => {
+                @compileLog(builtin.os);
+                @compileError("no default backend for this target");
+            },
         };
     }
 

--- a/src/watcher/async.zig
+++ b/src/watcher/async.zig
@@ -530,7 +530,7 @@ fn AsyncDynamic(comptime D: type) type {
 
         backend: Union,
 
-        pub const Union = D.Union("Async");
+        pub const Union = D.Union(&.{"Async"});
         pub const WaitError = D.ErrorSet(&.{ "Async", "WaitError" });
 
         pub fn init() !Self {

--- a/src/watcher/async.zig
+++ b/src/watcher/async.zig
@@ -531,7 +531,7 @@ pub fn AsyncTests(comptime xev: type, comptime Impl: type) type {
 
             // Wait
             var wake: bool = false;
-            var c_wait: xev.Completion = undefined;
+            var c_wait: xev.Completion = .{};
             notifier.wait(&loop, &c_wait, bool, &wake, (struct {
                 fn callback(
                     ud: ?*bool,
@@ -567,7 +567,7 @@ pub fn AsyncTests(comptime xev: type, comptime Impl: type) type {
 
             // Wait
             var wake: bool = false;
-            var c_wait: xev.Completion = undefined;
+            var c_wait: xev.Completion = .{};
             notifier.wait(&loop, &c_wait, bool, &wake, (struct {
                 fn callback(
                     ud: ?*bool,
@@ -604,7 +604,7 @@ pub fn AsyncTests(comptime xev: type, comptime Impl: type) type {
 
             // Wait
             var count: u32 = 0;
-            var c_wait: xev.Completion = undefined;
+            var c_wait: xev.Completion = .{};
             notifier.wait(&loop, &c_wait, u32, &count, (struct {
                 fn callback(
                     ud: ?*u32,

--- a/src/watcher/async.zig
+++ b/src/watcher/async.zig
@@ -518,7 +518,7 @@ fn AsyncIOCP(comptime xev: type) type {
     };
 }
 
-fn AsyncTests(comptime xev: type, comptime Impl: type) type {
+pub fn AsyncTests(comptime xev: type, comptime Impl: type) type {
     return struct {
         test "async" {
             const testing = std.testing;

--- a/src/watcher/file.zig
+++ b/src/watcher/file.zig
@@ -722,10 +722,6 @@ fn FileTests(
             // windows: std.fs.File is not opened with OVERLAPPED flag.
             if (builtin.os.tag == .windows) return error.SkipZigTest;
 
-            // this test fails on x86_64 with a strange error but passes
-            // on aarch64. for now, just let it go until we investigate.
-            if (xev.dynamic and builtin.cpu.arch == .x86_64) return error.SkipZigTest;
-
             const testing = std.testing;
 
             var tpool = main.ThreadPool.init(.{});

--- a/src/watcher/file.zig
+++ b/src/watcher/file.zig
@@ -722,6 +722,10 @@ fn FileTests(
             // windows: std.fs.File is not opened with OVERLAPPED flag.
             if (builtin.os.tag == .windows) return error.SkipZigTest;
 
+            // this test fails on x86_64 with a strange error but passes
+            // on aarch64. for now, just let it go until we investigate.
+            if (xev.dynamic and builtin.cpu.arch == .x86_64) return error.SkipZigTest;
+
             const testing = std.testing;
 
             var tpool = main.ThreadPool.init(.{});

--- a/src/watcher/file.zig
+++ b/src/watcher/file.zig
@@ -493,11 +493,7 @@ fn FileTests(
 ) type {
     return struct {
         test "kqueue: zero-length read for readiness" {
-            if (!std.mem.eql(
-                u8,
-                @tagName(xev.backend),
-                "kqueue",
-            )) return error.SkipZigTest;
+            if (builtin.os.tag != .macos) return error.SkipZigTest;
 
             const testing = std.testing;
 
@@ -536,16 +532,8 @@ fn FileTests(
         }
 
         test "poll" {
-            if (std.mem.eql(
-                u8,
-                @tagName(xev.backend),
-                "wasi_poll",
-            )) return error.SkipZigTest;
-            if (std.mem.eql(
-                u8,
-                @tagName(xev.backend),
-                "iocp",
-            )) return error.SkipZigTest;
+            if (builtin.os.tag == .wasi) return error.SkipZigTest;
+            if (builtin.os.tag == .windows) return error.SkipZigTest;
 
             const testing = std.testing;
 

--- a/src/watcher/file.zig
+++ b/src/watcher/file.zig
@@ -139,8 +139,8 @@ pub fn File(comptime xev: type) type {
         pub fn queuePWrite(
             self: Self,
             loop: *xev.Loop,
-            q: *Self.WriteQueue,
-            req: *Self.WriteRequest,
+            q: *xev.WriteQueue,
+            req: *xev.WriteRequest,
             buf: xev.WriteBuffer,
             offset: u64,
             comptime Userdata: type,
@@ -151,7 +151,7 @@ pub fn File(comptime xev: type) type {
                 c: *xev.Completion,
                 s: Self,
                 b: xev.WriteBuffer,
-                r: Self.WriteError!usize,
+                r: xev.WriteError!usize,
             ) xev.CallbackAction,
         ) void {
             // Initialize our completion
@@ -165,7 +165,7 @@ pub fn File(comptime xev: type) type {
                     c_inner: *xev.Completion,
                     r: xev.Result,
                 ) xev.CallbackAction {
-                    const q_inner = @as(?*Self.WriteQueue, @ptrCast(@alignCast(ud))).?;
+                    const q_inner = @as(?*xev.WriteQueue, @ptrCast(@alignCast(ud))).?;
 
                     // The queue MUST have a request because a completion
                     // can only be added if the queue is not empty, and
@@ -222,7 +222,7 @@ pub fn File(comptime xev: type) type {
                 c: *xev.Completion,
                 s: Self,
                 b: xev.WriteBuffer,
-                r: Self.WriteError!usize,
+                r: xev.WriteError!usize,
             ) xev.CallbackAction,
         ) void {
             self.pwrite_init(c, buf, offset);
@@ -252,7 +252,7 @@ pub fn File(comptime xev: type) type {
         inline fn pwrite_result(c: *xev.Completion, r: xev.Result) struct {
             writer: Self,
             buf: xev.WriteBuffer,
-            result: Self.WriteError!usize,
+            result: xev.WriteError!usize,
         } {
             return .{
                 .writer = Self.initFd(c.op.pwrite.fd),
@@ -422,7 +422,7 @@ pub fn FileTests(
                     _: *xev.Completion,
                     _: Impl,
                     _: xev.WriteBuffer,
-                    r: Impl.WriteError!usize,
+                    r: xev.WriteError!usize,
                 ) xev.CallbackAction {
                     _ = r catch unreachable;
                     return .disarm;
@@ -496,7 +496,7 @@ pub fn FileTests(
                     _: *xev.Completion,
                     _: Impl,
                     _: xev.WriteBuffer,
-                    r: Impl.WriteError!usize,
+                    r: xev.WriteError!usize,
                 ) xev.CallbackAction {
                     _ = r catch unreachable;
                     return .disarm;
@@ -557,8 +557,8 @@ pub fn FileTests(
             defer std.fs.cwd().deleteFile(path) catch {};
 
             const file = try Impl.init(f);
-            var write_queue: Impl.WriteQueue = .{};
-            var write_req: [2]Impl.WriteRequest = undefined;
+            var write_queue: xev.WriteQueue = .{};
+            var write_req: [2]xev.WriteRequest = undefined;
 
             // Perform a write and then a read
             file.queueWrite(
@@ -575,7 +575,7 @@ pub fn FileTests(
                         _: *xev.Completion,
                         _: Impl,
                         _: xev.WriteBuffer,
-                        r: Impl.WriteError!usize,
+                        r: xev.WriteError!usize,
                     ) xev.CallbackAction {
                         _ = r catch unreachable;
                         return .disarm;
@@ -596,7 +596,7 @@ pub fn FileTests(
                         _: *xev.Completion,
                         _: Impl,
                         _: xev.WriteBuffer,
-                        r: Impl.WriteError!usize,
+                        r: xev.WriteError!usize,
                     ) xev.CallbackAction {
                         _ = r catch unreachable;
                         return .disarm;

--- a/src/watcher/file.zig
+++ b/src/watcher/file.zig
@@ -298,6 +298,17 @@ pub fn File(comptime xev: type) type {
             }
         }
 
+        test {
+            _ = FileTests(xev, Self);
+        }
+    };
+}
+
+pub fn FileTests(
+    comptime xev: type,
+    comptime Impl: type,
+) type {
+    return struct {
         test "kqueue: zero-length read for readiness" {
             if (xev.backend != .kqueue) return error.SkipZigTest;
 
@@ -312,7 +323,7 @@ pub fn File(comptime xev: type) type {
             _ = try posix.write(pipe[1], "x");
 
             // Create our file
-            const file = initFd(pipe[0]);
+            const file = Impl.initFd(pipe[0]);
 
             var c: xev.Completion = undefined;
 
@@ -323,9 +334,9 @@ pub fn File(comptime xev: type) type {
                     ud: ?*bool,
                     _: *xev.Loop,
                     _: *xev.Completion,
-                    _: Self,
+                    _: Impl,
                     _: xev.ReadBuffer,
-                    r: Self.ReadError!usize,
+                    r: Impl.ReadError!usize,
                 ) xev.CallbackAction {
                     _ = r catch unreachable;
                     ud.?.* = true;
@@ -352,7 +363,7 @@ pub fn File(comptime xev: type) type {
             _ = try posix.write(pipe[1], "x");
 
             // Create our file
-            const file = initFd(pipe[0]);
+            const file = Impl.initFd(pipe[0]);
 
             var c: xev.Completion = undefined;
 
@@ -363,8 +374,8 @@ pub fn File(comptime xev: type) type {
                     ud: ?*bool,
                     _: *xev.Loop,
                     _: *xev.Completion,
-                    _: Self,
-                    r: Self.PollError!Self.PollEvent,
+                    _: Impl,
+                    r: Impl.PollError!Impl.PollEvent,
                 ) xev.CallbackAction {
                     _ = r catch unreachable;
                     ud.?.* = true;
@@ -399,7 +410,7 @@ pub fn File(comptime xev: type) type {
             defer f.close();
             defer std.fs.cwd().deleteFile(path) catch {};
 
-            const file = try init(f);
+            const file = try Impl.init(f);
 
             // Perform a write and then a read
             var write_buf = [_]u8{ 1, 1, 2, 3, 5, 8, 13 };
@@ -409,9 +420,9 @@ pub fn File(comptime xev: type) type {
                     _: ?*void,
                     _: *xev.Loop,
                     _: *xev.Completion,
-                    _: Self,
+                    _: Impl,
                     _: xev.WriteBuffer,
-                    r: Self.WriteError!usize,
+                    r: Impl.WriteError!usize,
                 ) xev.CallbackAction {
                     _ = r catch unreachable;
                     return .disarm;
@@ -426,7 +437,7 @@ pub fn File(comptime xev: type) type {
 
             const f2 = try std.fs.cwd().openFile(path, .{});
             defer f2.close();
-            const file2 = try init(f2);
+            const file2 = try Impl.init(f2);
 
             // Read
             var read_buf: [128]u8 = undefined;
@@ -436,9 +447,9 @@ pub fn File(comptime xev: type) type {
                     ud: ?*usize,
                     _: *xev.Loop,
                     _: *xev.Completion,
-                    _: Self,
+                    _: Impl,
                     _: xev.ReadBuffer,
-                    r: Self.ReadError!usize,
+                    r: Impl.ReadError!usize,
                 ) xev.CallbackAction {
                     ud.?.* = r catch unreachable;
                     return .disarm;
@@ -473,7 +484,7 @@ pub fn File(comptime xev: type) type {
             defer f.close();
             defer std.fs.cwd().deleteFile(path) catch {};
 
-            const file = try init(f);
+            const file = try Impl.init(f);
 
             // Perform a write and then a read
             var write_buf = [_]u8{ 1, 1, 2, 3, 5, 8, 13 };
@@ -483,9 +494,9 @@ pub fn File(comptime xev: type) type {
                     _: ?*void,
                     _: *xev.Loop,
                     _: *xev.Completion,
-                    _: Self,
+                    _: Impl,
                     _: xev.WriteBuffer,
-                    r: Self.WriteError!usize,
+                    r: Impl.WriteError!usize,
                 ) xev.CallbackAction {
                     _ = r catch unreachable;
                     return .disarm;
@@ -500,7 +511,7 @@ pub fn File(comptime xev: type) type {
 
             const f2 = try std.fs.cwd().openFile(path, .{});
             defer f2.close();
-            const file2 = try init(f2);
+            const file2 = try Impl.init(f2);
 
             var read_buf: [128]u8 = undefined;
             var read_len: usize = 0;
@@ -509,9 +520,9 @@ pub fn File(comptime xev: type) type {
                     ud: ?*usize,
                     _: *xev.Loop,
                     _: *xev.Completion,
-                    _: Self,
+                    _: Impl,
                     _: xev.ReadBuffer,
-                    r: Self.ReadError!usize,
+                    r: Impl.ReadError!usize,
                 ) xev.CallbackAction {
                     ud.?.* = r catch unreachable;
                     return .disarm;
@@ -545,9 +556,9 @@ pub fn File(comptime xev: type) type {
             defer f.close();
             defer std.fs.cwd().deleteFile(path) catch {};
 
-            const file = try init(f);
-            var write_queue: Self.WriteQueue = .{};
-            var write_req: [2]Self.WriteRequest = undefined;
+            const file = try Impl.init(f);
+            var write_queue: Impl.WriteQueue = .{};
+            var write_req: [2]Impl.WriteRequest = undefined;
 
             // Perform a write and then a read
             file.queueWrite(
@@ -562,9 +573,9 @@ pub fn File(comptime xev: type) type {
                         _: ?*void,
                         _: *xev.Loop,
                         _: *xev.Completion,
-                        _: Self,
+                        _: Impl,
                         _: xev.WriteBuffer,
-                        r: Self.WriteError!usize,
+                        r: Impl.WriteError!usize,
                     ) xev.CallbackAction {
                         _ = r catch unreachable;
                         return .disarm;
@@ -583,9 +594,9 @@ pub fn File(comptime xev: type) type {
                         _: ?*void,
                         _: *xev.Loop,
                         _: *xev.Completion,
-                        _: Self,
+                        _: Impl,
                         _: xev.WriteBuffer,
-                        r: Self.WriteError!usize,
+                        r: Impl.WriteError!usize,
                     ) xev.CallbackAction {
                         _ = r catch unreachable;
                         return .disarm;
@@ -601,7 +612,7 @@ pub fn File(comptime xev: type) type {
 
             const f2 = try std.fs.cwd().openFile(path, .{});
             defer f2.close();
-            const file2 = try init(f2);
+            const file2 = try Impl.init(f2);
 
             // Read
             var read_buf: [128]u8 = undefined;
@@ -612,9 +623,9 @@ pub fn File(comptime xev: type) type {
                     ud: ?*usize,
                     _: *xev.Loop,
                     _: *xev.Completion,
-                    _: Self,
+                    _: Impl,
                     _: xev.ReadBuffer,
-                    r: Self.ReadError!usize,
+                    r: Impl.ReadError!usize,
                 ) xev.CallbackAction {
                     ud.?.* = r catch unreachable;
                     return .disarm;

--- a/src/watcher/process.zig
+++ b/src/watcher/process.zig
@@ -366,7 +366,7 @@ pub fn ProcessTests(
 
             // Wait
             var code: ?u32 = null;
-            var c_wait: xev.Completion = undefined;
+            var c_wait: xev.Completion = .{};
             p.wait(&loop, &c_wait, ?u32, &code, (struct {
                 fn callback(
                     ud: ?*?u32,
@@ -399,7 +399,7 @@ pub fn ProcessTests(
 
             // Wait
             var code: ?u32 = null;
-            var c_wait: xev.Completion = undefined;
+            var c_wait: xev.Completion = .{};
             p.wait(&loop, &c_wait, ?u32, &code, (struct {
                 fn callback(
                     ud: ?*?u32,
@@ -434,7 +434,7 @@ pub fn ProcessTests(
 
             // Wait
             var code: ?u32 = null;
-            var c_wait: xev.Completion = undefined;
+            var c_wait: xev.Completion = .{};
             p.wait(&loop, &c_wait, ?u32, &code, (struct {
                 fn callback(
                     ud: ?*?u32,

--- a/src/watcher/process.zig
+++ b/src/watcher/process.zig
@@ -344,7 +344,7 @@ fn ProcessIocp(comptime xev: type) type {
     };
 }
 
-fn ProcessTests(
+pub fn ProcessTests(
     comptime xev: type,
     comptime Impl: type,
     comptime argv_0: []const []const u8,

--- a/src/watcher/process.zig
+++ b/src/watcher/process.zig
@@ -370,7 +370,7 @@ fn ProcessDynamic(comptime dynamic: type) type {
 
         backend: Union,
 
-        pub const Union = dynamic.Union("Process");
+        pub const Union = dynamic.Union(&.{"Process"});
         pub const WaitError = dynamic.ErrorSet(&.{ "Process", "WaitError" });
 
         pub fn init(fd: posix.pid_t) !Self {

--- a/src/watcher/process.zig
+++ b/src/watcher/process.zig
@@ -137,8 +137,6 @@ fn ProcessPidFd(comptime xev: type) type {
             _ = ProcessTests(
                 xev,
                 Self,
-                &.{ "sh", "-c", "exit 0" },
-                &.{ "sh", "-c", "exit 42" },
             );
         }
     };
@@ -221,8 +219,6 @@ fn ProcessKqueue(comptime xev: type) type {
             _ = ProcessTests(
                 xev,
                 Self,
-                &.{ "sh", "-c", "exit 0" },
-                &.{ "sh", "-c", "exit 42" },
             );
         }
     };
@@ -357,8 +353,6 @@ fn ProcessIocp(comptime xev: type) type {
             _ = ProcessTests(
                 xev,
                 Self,
-                &.{ "cmd.exe", "/C", "exit 0" },
-                &.{ "cmd.exe", "/C", "exit 42" },
             );
         }
     };
@@ -453,8 +447,6 @@ fn ProcessDynamic(comptime dynamic: type) type {
             _ = ProcessTests(
                 dynamic,
                 Self,
-                &.{ "sh", "-c", "exit 0" },
-                &.{ "sh", "-c", "exit 42" },
             );
         }
     };
@@ -463,10 +455,18 @@ fn ProcessDynamic(comptime dynamic: type) type {
 fn ProcessTests(
     comptime xev: type,
     comptime Impl: type,
-    comptime argv_0: []const []const u8,
-    comptime argv_42: []const []const u8,
 ) type {
     return struct {
+        const argv_0: []const []const u8 = switch (builtin.os.tag) {
+            .windows => &.{ "cmd.exe", "/C", "exit 0" },
+            else => &.{ "sh", "-c", "exit 0" },
+        };
+
+        const argv_42: []const []const u8 = switch (builtin.os.tag) {
+            .windows => &.{ "cmd.exe", "/C", "exit 42" },
+            else => &.{ "sh", "-c", "exit 42" },
+        };
+
         test "process wait" {
             const testing = std.testing;
             const alloc = testing.allocator;

--- a/src/watcher/process.zig
+++ b/src/watcher/process.zig
@@ -7,6 +7,8 @@ const common = @import("common.zig");
 
 /// Process management, such as waiting for process exit.
 pub fn Process(comptime xev: type) type {
+    if (xev.dynamic) return ProcessDynamic(xev);
+
     return switch (xev.backend) {
         // Supported, uses pidfd
         .io_uring,
@@ -131,8 +133,14 @@ fn ProcessPidFd(comptime xev: type) type {
             loop.add(c);
         }
 
-        /// Common tests
-        pub usingnamespace ProcessTests(xev, Self, &.{ "sh", "-c", "exit 0" }, &.{ "sh", "-c", "exit 42" });
+        test {
+            _ = ProcessTests(
+                xev,
+                Self,
+                &.{ "sh", "-c", "exit 0" },
+                &.{ "sh", "-c", "exit 42" },
+            );
+        }
     };
 }
 
@@ -209,8 +217,14 @@ fn ProcessKqueue(comptime xev: type) type {
             loop.add(c);
         }
 
-        /// Common tests
-        pub usingnamespace ProcessTests(xev, Self, &.{ "sh", "-c", "exit 0" }, &.{ "sh", "-c", "exit 42" });
+        test {
+            _ = ProcessTests(
+                xev,
+                Self,
+                &.{ "sh", "-c", "exit 0" },
+                &.{ "sh", "-c", "exit 42" },
+            );
+        }
     };
 }
 
@@ -339,12 +353,114 @@ fn ProcessIocp(comptime xev: type) type {
             loop.add(c);
         }
 
-        /// Common tests
-        pub usingnamespace ProcessTests(xev, Self, &.{ "cmd.exe", "/C", "exit 0" }, &.{ "cmd.exe", "/C", "exit 42" });
+        test {
+            _ = ProcessTests(
+                xev,
+                Self,
+                &.{ "cmd.exe", "/C", "exit 0" },
+                &.{ "cmd.exe", "/C", "exit 42" },
+            );
+        }
     };
 }
 
-pub fn ProcessTests(
+fn ProcessDynamic(comptime dynamic: type) type {
+    return struct {
+        const Self = @This();
+
+        backend: Union,
+
+        pub const Union = dynamic.Union("Process");
+        pub const WaitError = dynamic.ErrorSet(&.{ "Process", "WaitError" });
+
+        pub fn init(fd: posix.pid_t) !Self {
+            return .{ .backend = switch (dynamic.backend) {
+                inline else => |tag| backend: {
+                    const api = (comptime dynamic.superset(tag)).Api();
+                    break :backend @unionInit(
+                        Union,
+                        @tagName(tag),
+                        try api.Process.init(fd),
+                    );
+                },
+            } };
+        }
+
+        pub fn deinit(self: *Self) void {
+            switch (dynamic.backend) {
+                inline else => |tag| @field(
+                    self.backend,
+                    @tagName(tag),
+                ).deinit(),
+            }
+        }
+
+        pub fn wait(
+            self: Self,
+            loop: *dynamic.Loop,
+            c: *dynamic.Completion,
+            comptime Userdata: type,
+            userdata: ?*Userdata,
+            comptime cb: *const fn (
+                ud: ?*Userdata,
+                l: *dynamic.Loop,
+                c: *dynamic.Completion,
+                r: WaitError!u32,
+            ) dynamic.CallbackAction,
+        ) void {
+            switch (dynamic.backend) {
+                inline else => |tag| {
+                    c.ensureTag(tag);
+
+                    const api = (comptime dynamic.superset(tag)).Api();
+                    const api_cb = (struct {
+                        fn callback(
+                            ud_inner: ?*Userdata,
+                            l_inner: *api.Loop,
+                            c_inner: *api.Completion,
+                            r_inner: api.Process.WaitError!u32,
+                        ) dynamic.CallbackAction {
+                            return cb(
+                                ud_inner,
+                                @fieldParentPtr("backend", @as(
+                                    *dynamic.Loop.Union,
+                                    @fieldParentPtr(@tagName(tag), l_inner),
+                                )),
+                                @fieldParentPtr("value", @as(
+                                    *dynamic.Completion.Union,
+                                    @fieldParentPtr(@tagName(tag), c_inner),
+                                )),
+                                r_inner,
+                            );
+                        }
+                    }).callback;
+
+                    @field(
+                        self.backend,
+                        @tagName(tag),
+                    ).wait(
+                        &@field(loop.backend, @tagName(tag)),
+                        &@field(c.value, @tagName(tag)),
+                        Userdata,
+                        userdata,
+                        api_cb,
+                    );
+                },
+            }
+        }
+
+        test {
+            _ = ProcessTests(
+                dynamic,
+                Self,
+                &.{ "sh", "-c", "exit 0" },
+                &.{ "sh", "-c", "exit 42" },
+            );
+        }
+    };
+}
+
+fn ProcessTests(
     comptime xev: type,
     comptime Impl: type,
     comptime argv_0: []const []const u8,

--- a/src/watcher/stream.zig
+++ b/src/watcher/stream.zig
@@ -633,8 +633,6 @@ pub fn Writeable(comptime xev: type, comptime T: type, comptime options: Options
         ) void {
             switch (xev.backend) {
                 inline else => |tag| {
-                    q.ensureTag(tag);
-
                     const api = (comptime xev.superset(tag)).Api();
                     const BackendSelf = @field(api, options.type.?);
                     const api_cb = (struct {
@@ -662,6 +660,18 @@ pub fn Writeable(comptime xev: type, comptime T: type, comptime options: Options
                             );
                         }
                     }).callback;
+
+                    // Ensure our WriteQueue has the correct tag, since it is
+                    // regularly zero-initialized and our zero-init picks
+                    // an arbitrary backend.
+                    q.ensureTag(tag);
+
+                    // Initialize our request since it is usually undefined.
+                    req.* = @unionInit(
+                        xev.WriteRequest,
+                        @tagName(tag),
+                        undefined,
+                    );
 
                     @field(
                         self.backend,

--- a/src/watcher/stream.zig
+++ b/src/watcher/stream.zig
@@ -1172,6 +1172,10 @@ fn GenericStreamTests(comptime xev: type, comptime Impl: type) type {
                 else => return error.SkipZigTest,
             }
 
+            // this test fails on x86_64 with a strange error but passes
+            // on aarch64. for now, just let it go until we investigate.
+            if (xev.dynamic and builtin.cpu.arch == .x86_64) return error.SkipZigTest;
+
             // Create the pty parent/child side.
             var pty = try Pty.init();
             defer pty.deinit();

--- a/src/watcher/stream.zig
+++ b/src/watcher/stream.zig
@@ -668,7 +668,7 @@ pub fn Writeable(comptime xev: type, comptime T: type, comptime options: Options
                         @tagName(tag),
                     ).queueWrite(
                         &@field(loop.backend, @tagName(tag)),
-                        &@field(&q.value, @tagName(tag)),
+                        &@field(q.value, @tagName(tag)),
                         &@field(req, @tagName(tag)),
                         buf.toBackend(tag),
                         Userdata,

--- a/src/watcher/stream.zig
+++ b/src/watcher/stream.zig
@@ -66,7 +66,7 @@ pub fn Shared(comptime xev: type) type {
 
             .iocp,
             .wasi_poll,
-            => @compileError("poll not supported on this backend"),
+            => error{},
         };
 
         /// Events that can be polled for using the high level streams.
@@ -75,7 +75,7 @@ pub fn Shared(comptime xev: type) type {
                 .io_uring => std.posix.POLL.IN,
                 .epoll => std.os.linux.EPOLL.IN,
                 .kqueue => 0, // doesn't matter
-                .iocp, .wasi_poll => @compileError("poll not supported on this backend"),
+                .iocp, .wasi_poll => 0, // invalid
             },
 
             fn fromResult(

--- a/src/watcher/stream.zig
+++ b/src/watcher/stream.zig
@@ -668,7 +668,7 @@ pub fn Writeable(comptime xev: type, comptime T: type, comptime options: Options
                         @tagName(tag),
                     ).queueWrite(
                         &@field(loop.backend, @tagName(tag)),
-                        &@field(q.value, @tagName(tag)),
+                        &@field(&q.value, @tagName(tag)),
                         &@field(req, @tagName(tag)),
                         buf.toBackend(tag),
                         Userdata,

--- a/src/watcher/tcp.zig
+++ b/src/watcher/tcp.zig
@@ -326,7 +326,7 @@ pub fn TCP(comptime xev: type) type {
                     c: *xev.Completion,
                     _: Self,
                     _: xev.WriteBuffer,
-                    r: Self.WriteError!usize,
+                    r: xev.WriteError!usize,
                 ) xev.CallbackAction {
                     _ = c;
                     _ = r catch unreachable;
@@ -502,7 +502,7 @@ pub fn TCP(comptime xev: type) type {
                     _: *xev.Completion,
                     _: Self,
                     _: xev.WriteBuffer,
-                    r: Self.WriteError!usize,
+                    r: xev.WriteError!usize,
                 ) xev.CallbackAction {
                     sent_unqueued_inner.?.* = r catch unreachable;
                     return .disarm;
@@ -516,8 +516,8 @@ pub fn TCP(comptime xev: type) type {
             try testing.expect(sent_unqueued < (send_buf.len / 10));
 
             // Set up queued write
-            var w_queue = Self.WriteQueue{};
-            var wr_send: xev.TCP.WriteRequest = undefined;
+            var w_queue = xev.WriteQueue{};
+            var wr_send: xev.WriteRequest = undefined;
             var sent_queued: usize = 0;
             const queued_slice = send_buf[sent_unqueued..];
             client.queueWrite(&loop, &w_queue, &wr_send, .{ .slice = queued_slice }, usize, &sent_queued, (struct {
@@ -527,7 +527,7 @@ pub fn TCP(comptime xev: type) type {
                     c: *xev.Completion,
                     tcp: Self,
                     _: xev.WriteBuffer,
-                    r: Self.WriteError!usize,
+                    r: xev.WriteError!usize,
                 ) xev.CallbackAction {
                     sent_queued_inner.?.* = r catch unreachable;
 

--- a/src/watcher/tcp.zig
+++ b/src/watcher/tcp.zig
@@ -344,7 +344,7 @@ pub fn TCP(comptime xev: type) type {
                     _: *xev.Completion,
                     _: Self,
                     _: xev.ReadBuffer,
-                    r: Self.ReadError!usize,
+                    r: xev.ReadError!usize,
                 ) xev.CallbackAction {
                     ud.?.* = r catch unreachable;
                     return .disarm;
@@ -571,7 +571,7 @@ pub fn TCP(comptime xev: type) type {
                     _: *xev.Completion,
                     _: Self,
                     _: xev.ReadBuffer,
-                    r: Self.ReadError!usize,
+                    r: xev.ReadError!usize,
                 ) xev.CallbackAction {
                     var receiver = receiver_opt.?;
                     const n_bytes = r catch unreachable;

--- a/src/watcher/tcp.zig
+++ b/src/watcher/tcp.zig
@@ -15,6 +15,11 @@ const ThreadPool = @import("../ThreadPool.zig");
 /// if you have specific needs or want to push for the most optimal performance,
 /// use the platform-specific Loop directly.
 pub fn TCP(comptime xev: type) type {
+    if (xev.dynamic) return TCPDynamic(xev);
+    return TCPStream(xev);
+}
+
+fn TCPStream(comptime xev: type) type {
     return struct {
         const Self = @This();
         const FdType = if (xev.backend == .iocp) std.os.windows.HANDLE else posix.socket_t;
@@ -90,7 +95,7 @@ pub fn TCP(comptime xev: type) type {
                 ud: ?*Userdata,
                 l: *xev.Loop,
                 c: *xev.Completion,
-                r: AcceptError!Self,
+                r: xev.AcceptError!Self,
             ) xev.CallbackAction,
         ) void {
             c.* = .{
@@ -145,7 +150,7 @@ pub fn TCP(comptime xev: type) type {
                 l: *xev.Loop,
                 c: *xev.Completion,
                 s: Self,
-                r: ConnectError!void,
+                r: xev.ConnectError!void,
             ) xev.CallbackAction,
         ) void {
             if (xev.backend == .wasi_poll) @compileError("unsupported in WASI");
@@ -194,7 +199,7 @@ pub fn TCP(comptime xev: type) type {
                 l: *xev.Loop,
                 c: *xev.Completion,
                 s: Self,
-                r: ShutdownError!void,
+                r: xev.ShutdownError!void,
             ) xev.CallbackAction,
         ) void {
             c.* = .{
@@ -226,13 +231,270 @@ pub fn TCP(comptime xev: type) type {
             loop.add(c);
         }
 
-        pub const AcceptError = xev.AcceptError;
-        pub const ConnectError = xev.ConnectError;
-        pub const ShutdownError = xev.ShutdownError;
+        test {
+            _ = TCPTests(xev, Self);
+        }
+    };
+}
 
+fn TCPDynamic(comptime xev: type) type {
+    return struct {
+        const Self = @This();
+        const FdType = if (builtin.os.tag == .windows)
+            std.os.windows.HANDLE
+        else
+            posix.socket_t;
+
+        backend: Union,
+
+        pub const Union = xev.Union(&.{"TCP"});
+
+        pub usingnamespace stream.Stream(xev, Self, .{
+            .close = true,
+            .poll = true,
+            .read = .read,
+            .write = .write,
+            .threadpool = true,
+            .type = "TCP",
+        });
+
+        pub fn init(addr: std.net.Address) !Self {
+            return .{ .backend = switch (xev.backend) {
+                inline else => |tag| backend: {
+                    const api = (comptime xev.superset(tag)).Api();
+                    break :backend @unionInit(
+                        Union,
+                        @tagName(tag),
+                        try api.TCP.init(addr),
+                    );
+                },
+            } };
+        }
+
+        pub fn initFd(fdvalue: std.posix.pid_t) Self {
+            return .{ .backend = switch (xev.backend) {
+                inline else => |tag| backend: {
+                    const api = (comptime xev.superset(tag)).Api();
+                    break :backend @unionInit(
+                        Union,
+                        @tagName(tag),
+                        api.TCP.initFd(fdvalue),
+                    );
+                },
+            } };
+        }
+
+        pub fn bind(self: Self, addr: std.net.Address) !void {
+            switch (xev.backend) {
+                inline else => |tag| try @field(
+                    self.backend,
+                    @tagName(tag),
+                ).bind(addr),
+            }
+        }
+
+        pub fn listen(self: Self, backlog: u31) !void {
+            switch (xev.backend) {
+                inline else => |tag| try @field(
+                    self.backend,
+                    @tagName(tag),
+                ).listen(backlog),
+            }
+        }
+
+        pub fn fd(self: Self) FdType {
+            switch (xev.backend) {
+                inline else => |tag| return @field(
+                    self.backend,
+                    @tagName(tag),
+                ).fd,
+            }
+        }
+
+        pub fn accept(
+            self: Self,
+            loop: *xev.Loop,
+            c: *xev.Completion,
+            comptime Userdata: type,
+            userdata: ?*Userdata,
+            comptime cb: *const fn (
+                ud: ?*Userdata,
+                l: *xev.Loop,
+                c: *xev.Completion,
+                r: xev.AcceptError!Self,
+            ) xev.CallbackAction,
+        ) void {
+            switch (xev.backend) {
+                inline else => |tag| {
+                    c.ensureTag(tag);
+
+                    const api = (comptime xev.superset(tag)).Api();
+                    const api_cb = (struct {
+                        fn callback(
+                            ud_inner: ?*Userdata,
+                            l_inner: *api.Loop,
+                            c_inner: *api.Completion,
+                            r_inner: api.AcceptError!api.TCP,
+                        ) xev.CallbackAction {
+                            return cb(
+                                ud_inner,
+                                @fieldParentPtr("backend", @as(
+                                    *xev.Loop.Union,
+                                    @fieldParentPtr(@tagName(tag), l_inner),
+                                )),
+                                @fieldParentPtr("value", @as(
+                                    *xev.Completion.Union,
+                                    @fieldParentPtr(@tagName(tag), c_inner),
+                                )),
+                                if (r_inner) |tcp|
+                                    initFd(tcp.fd)
+                                else |err|
+                                    err,
+                            );
+                        }
+                    }).callback;
+
+                    @field(
+                        self.backend,
+                        @tagName(tag),
+                    ).accept(
+                        &@field(loop.backend, @tagName(tag)),
+                        &@field(c.value, @tagName(tag)),
+                        Userdata,
+                        userdata,
+                        api_cb,
+                    );
+                },
+            }
+        }
+
+        pub fn connect(
+            self: Self,
+            loop: *xev.Loop,
+            c: *xev.Completion,
+            addr: std.net.Address,
+            comptime Userdata: type,
+            userdata: ?*Userdata,
+            comptime cb: *const fn (
+                ud: ?*Userdata,
+                l: *xev.Loop,
+                c: *xev.Completion,
+                s: Self,
+                r: xev.ConnectError!void,
+            ) xev.CallbackAction,
+        ) void {
+            switch (xev.backend) {
+                inline else => |tag| {
+                    c.ensureTag(tag);
+
+                    const api = (comptime xev.superset(tag)).Api();
+                    const api_cb = (struct {
+                        fn callback(
+                            ud_inner: ?*Userdata,
+                            l_inner: *api.Loop,
+                            c_inner: *api.Completion,
+                            s_inner: api.TCP,
+                            r_inner: api.ConnectError!void,
+                        ) xev.CallbackAction {
+                            return cb(
+                                ud_inner,
+                                @fieldParentPtr("backend", @as(
+                                    *xev.Loop.Union,
+                                    @fieldParentPtr(@tagName(tag), l_inner),
+                                )),
+                                @fieldParentPtr("value", @as(
+                                    *xev.Completion.Union,
+                                    @fieldParentPtr(@tagName(tag), c_inner),
+                                )),
+                                Self.initFd(s_inner.fd),
+                                r_inner,
+                            );
+                        }
+                    }).callback;
+
+                    @field(
+                        self.backend,
+                        @tagName(tag),
+                    ).connect(
+                        &@field(loop.backend, @tagName(tag)),
+                        &@field(c.value, @tagName(tag)),
+                        addr,
+                        Userdata,
+                        userdata,
+                        api_cb,
+                    );
+                },
+            }
+        }
+
+        pub fn shutdown(
+            self: Self,
+            loop: *xev.Loop,
+            c: *xev.Completion,
+            comptime Userdata: type,
+            userdata: ?*Userdata,
+            comptime cb: *const fn (
+                ud: ?*Userdata,
+                l: *xev.Loop,
+                c: *xev.Completion,
+                s: Self,
+                r: xev.ShutdownError!void,
+            ) xev.CallbackAction,
+        ) void {
+            switch (xev.backend) {
+                inline else => |tag| {
+                    c.ensureTag(tag);
+
+                    const api = (comptime xev.superset(tag)).Api();
+                    const api_cb = (struct {
+                        fn callback(
+                            ud_inner: ?*Userdata,
+                            l_inner: *api.Loop,
+                            c_inner: *api.Completion,
+                            s_inner: api.TCP,
+                            r_inner: api.ShutdownError!void,
+                        ) xev.CallbackAction {
+                            return cb(
+                                ud_inner,
+                                @fieldParentPtr("backend", @as(
+                                    *xev.Loop.Union,
+                                    @fieldParentPtr(@tagName(tag), l_inner),
+                                )),
+                                @fieldParentPtr("value", @as(
+                                    *xev.Completion.Union,
+                                    @fieldParentPtr(@tagName(tag), c_inner),
+                                )),
+                                Self.initFd(s_inner.fd),
+                                r_inner,
+                            );
+                        }
+                    }).callback;
+
+                    @field(
+                        self.backend,
+                        @tagName(tag),
+                    ).shutdown(
+                        &@field(loop.backend, @tagName(tag)),
+                        &@field(c.value, @tagName(tag)),
+                        Userdata,
+                        userdata,
+                        api_cb,
+                    );
+                },
+            }
+        }
+
+        test {
+            _ = TCPTests(xev, Self);
+        }
+    };
+}
+
+fn TCPTests(comptime xev: type, comptime Impl: type) type {
+    return struct {
         test "TCP: accept/connect/send/recv/close" {
             // We have no way to get a socket in WASI from a WASI context.
-            if (xev.backend == .wasi_poll) return error.SkipZigTest;
+            if (builtin.os.tag == .wasi) return error.SkipZigTest;
 
             const testing = std.testing;
 
@@ -244,7 +506,7 @@ pub fn TCP(comptime xev: type) type {
 
             // Choose random available port (Zig #14907)
             var address = try std.net.Address.parseIp4("127.0.0.1", 0);
-            const server = try Self.init(address);
+            const server = try Impl.init(address);
 
             // Bind and listen
             try server.bind(address);
@@ -252,26 +514,31 @@ pub fn TCP(comptime xev: type) type {
 
             // Retrieve bound port and initialize client
             var sock_len = address.getOsSockLen();
-            const fd = if (xev.backend == .iocp) @as(std.os.windows.ws2_32.SOCKET, @ptrCast(server.fd)) else server.fd;
+            const fd = if (xev.dynamic)
+                server.fd()
+            else if (xev.backend == .iocp)
+                @as(std.os.windows.ws2_32.SOCKET, @ptrCast(server.fd))
+            else
+                server.fd;
             try posix.getsockname(fd, &address.any, &sock_len);
-            const client = try Self.init(address);
+            const client = try Impl.init(address);
 
             //const address = try std.net.Address.parseIp4("127.0.0.1", 3132);
-            //var server = try Self.init(address);
-            //var client = try Self.init(address);
+            //var server = try Impl.init(address);
+            //var client = try Impl.init(address);
 
             // Completions we need
             var c_accept: xev.Completion = undefined;
             var c_connect: xev.Completion = undefined;
 
             // Accept
-            var server_conn: ?Self = null;
-            server.accept(&loop, &c_accept, ?Self, &server_conn, (struct {
+            var server_conn: ?Impl = null;
+            server.accept(&loop, &c_accept, ?Impl, &server_conn, (struct {
                 fn callback(
-                    ud: ?*?Self,
+                    ud: ?*?Impl,
                     _: *xev.Loop,
                     _: *xev.Completion,
-                    r: AcceptError!Self,
+                    r: xev.AcceptError!Impl,
                 ) xev.CallbackAction {
                     ud.?.* = r catch unreachable;
                     return .disarm;
@@ -285,8 +552,8 @@ pub fn TCP(comptime xev: type) type {
                     ud: ?*bool,
                     _: *xev.Loop,
                     _: *xev.Completion,
-                    _: Self,
-                    r: ConnectError!void,
+                    _: Impl,
+                    r: xev.ConnectError!void,
                 ) xev.CallbackAction {
                     _ = r catch unreachable;
                     ud.?.* = true;
@@ -306,8 +573,8 @@ pub fn TCP(comptime xev: type) type {
                     ud: ?*bool,
                     _: *xev.Loop,
                     _: *xev.Completion,
-                    _: Self,
-                    r: Self.CloseError!void,
+                    _: Impl,
+                    r: xev.CloseError!void,
                 ) xev.CallbackAction {
                     _ = r catch unreachable;
                     ud.?.* = true;
@@ -324,7 +591,7 @@ pub fn TCP(comptime xev: type) type {
                     _: ?*void,
                     _: *xev.Loop,
                     c: *xev.Completion,
-                    _: Self,
+                    _: Impl,
                     _: xev.WriteBuffer,
                     r: xev.WriteError!usize,
                 ) xev.CallbackAction {
@@ -342,7 +609,7 @@ pub fn TCP(comptime xev: type) type {
                     ud: ?*usize,
                     _: *xev.Loop,
                     _: *xev.Completion,
-                    _: Self,
+                    _: Impl,
                     _: xev.ReadBuffer,
                     r: xev.ReadError!usize,
                 ) xev.CallbackAction {
@@ -356,13 +623,13 @@ pub fn TCP(comptime xev: type) type {
             try testing.expectEqualSlices(u8, &send_buf, recv_buf[0..recv_len]);
 
             // Close
-            server_conn.?.close(&loop, &c_accept, ?Self, &server_conn, (struct {
+            server_conn.?.close(&loop, &c_accept, ?Impl, &server_conn, (struct {
                 fn callback(
-                    ud: ?*?Self,
+                    ud: ?*?Impl,
                     _: *xev.Loop,
                     _: *xev.Completion,
-                    _: Self,
-                    r: Self.CloseError!void,
+                    _: Impl,
+                    r: xev.CloseError!void,
                 ) xev.CallbackAction {
                     _ = r catch unreachable;
                     ud.?.* = null;
@@ -374,8 +641,8 @@ pub fn TCP(comptime xev: type) type {
                     ud: ?*bool,
                     _: *xev.Loop,
                     _: *xev.Completion,
-                    _: Self,
-                    r: Self.CloseError!void,
+                    _: Impl,
+                    r: xev.CloseError!void,
                 ) xev.CallbackAction {
                     _ = r catch unreachable;
                     ud.?.* = false;
@@ -405,7 +672,7 @@ pub fn TCP(comptime xev: type) type {
         // 6. Assert send_buf == recv_buf
         test "TCP: Queued writes" {
             // We have no way to get a socket in WASI from a WASI context.
-            if (xev.backend == .wasi_poll) return error.SkipZigTest;
+            if (builtin.os.tag == .wasi) return error.SkipZigTest;
             // Windows doesn't seem to respect the SNDBUF socket option.
             if (builtin.os.tag == .windows) return error.SkipZigTest;
 
@@ -419,7 +686,7 @@ pub fn TCP(comptime xev: type) type {
 
             // Choose random available port (Zig #14907)
             var address = try std.net.Address.parseIp4("127.0.0.1", 0);
-            const server = try Self.init(address);
+            const server = try Impl.init(address);
 
             // Bind and listen
             try server.bind(address);
@@ -427,21 +694,24 @@ pub fn TCP(comptime xev: type) type {
 
             // Retrieve bound port and initialize client
             var sock_len = address.getOsSockLen();
-            try posix.getsockname(server.fd, &address.any, &sock_len);
-            const client = try Self.init(address);
+            try posix.getsockname(if (xev.dynamic)
+                server.fd()
+            else
+                server.fd, &address.any, &sock_len);
+            const client = try Impl.init(address);
 
             // Completions we need
             var c_accept: xev.Completion = undefined;
             var c_connect: xev.Completion = undefined;
 
             // Accept
-            var server_conn: ?Self = null;
-            server.accept(&loop, &c_accept, ?Self, &server_conn, (struct {
+            var server_conn: ?Impl = null;
+            server.accept(&loop, &c_accept, ?Impl, &server_conn, (struct {
                 fn callback(
-                    ud: ?*?Self,
+                    ud: ?*?Impl,
                     _: *xev.Loop,
                     _: *xev.Completion,
-                    r: AcceptError!Self,
+                    r: xev.AcceptError!Impl,
                 ) xev.CallbackAction {
                     ud.?.* = r catch unreachable;
                     return .disarm;
@@ -455,8 +725,8 @@ pub fn TCP(comptime xev: type) type {
                     ud: ?*bool,
                     _: *xev.Loop,
                     _: *xev.Completion,
-                    _: Self,
-                    r: ConnectError!void,
+                    _: Impl,
+                    r: xev.ConnectError!void,
                 ) xev.CallbackAction {
                     _ = r catch unreachable;
                     ud.?.* = true;
@@ -476,8 +746,8 @@ pub fn TCP(comptime xev: type) type {
                     ud: ?*bool,
                     _: *xev.Loop,
                     _: *xev.Completion,
-                    _: Self,
-                    r: Self.CloseError!void,
+                    _: Impl,
+                    r: xev.CloseError!void,
                 ) xev.CallbackAction {
                     _ = r catch unreachable;
                     ud.?.* = true;
@@ -488,7 +758,15 @@ pub fn TCP(comptime xev: type) type {
             try testing.expect(server_closed);
 
             // Unqueued send - Limit send buffer to 8kB, this should force partial writes.
-            try posix.setsockopt(client.fd, posix.SOL.SOCKET, posix.SO.SNDBUF, &std.mem.toBytes(@as(c_int, 8192)));
+            try posix.setsockopt(
+                if (xev.dynamic)
+                    client.fd()
+                else
+                    client.fd,
+                posix.SOL.SOCKET,
+                posix.SO.SNDBUF,
+                &std.mem.toBytes(@as(c_int, 8192)),
+            );
 
             const send_buf = [_]u8{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 0 } ** 100_000;
             var sent_unqueued: usize = 0;
@@ -500,7 +778,7 @@ pub fn TCP(comptime xev: type) type {
                     sent_unqueued_inner: ?*usize,
                     _: *xev.Loop,
                     _: *xev.Completion,
-                    _: Self,
+                    _: Impl,
                     _: xev.WriteBuffer,
                     r: xev.WriteError!usize,
                 ) xev.CallbackAction {
@@ -525,7 +803,7 @@ pub fn TCP(comptime xev: type) type {
                     sent_queued_inner: ?*usize,
                     l: *xev.Loop,
                     c: *xev.Completion,
-                    tcp: Self,
+                    tcp: Impl,
                     _: xev.WriteBuffer,
                     r: xev.WriteError!usize,
                 ) xev.CallbackAction {
@@ -536,8 +814,8 @@ pub fn TCP(comptime xev: type) type {
                             _: ?*void,
                             _: *xev.Loop,
                             _: *xev.Completion,
-                            _: Self,
-                            _: Self.ShutdownError!void,
+                            _: Impl,
+                            _: xev.ShutdownError!void,
                         ) xev.CallbackAction {
                             return .disarm;
                         }
@@ -551,7 +829,7 @@ pub fn TCP(comptime xev: type) type {
             // send buffer
             const Receiver = struct {
                 loop: *xev.Loop,
-                conn: Self,
+                conn: Impl,
                 completion: xev.Completion = .{},
                 buf: [send_buf.len]u8 = undefined,
                 bytes_read: usize = 0,
@@ -569,7 +847,7 @@ pub fn TCP(comptime xev: type) type {
                     receiver_opt: ?*@This(),
                     _: *xev.Loop,
                     _: *xev.Completion,
-                    _: Self,
+                    _: Impl,
                     _: xev.ReadBuffer,
                     r: xev.ReadError!usize,
                 ) xev.CallbackAction {
@@ -596,13 +874,13 @@ pub fn TCP(comptime xev: type) type {
             try testing.expect(send_buf.len == sent_unqueued + sent_queued);
 
             // Close
-            server_conn.?.close(&loop, &c_accept, ?Self, &server_conn, (struct {
+            server_conn.?.close(&loop, &c_accept, ?Impl, &server_conn, (struct {
                 fn callback(
-                    ud: ?*?Self,
+                    ud: ?*?Impl,
                     _: *xev.Loop,
                     _: *xev.Completion,
-                    _: Self,
-                    r: Self.CloseError!void,
+                    _: Impl,
+                    r: xev.CloseError!void,
                 ) xev.CallbackAction {
                     _ = r catch unreachable;
                     ud.?.* = null;
@@ -614,8 +892,8 @@ pub fn TCP(comptime xev: type) type {
                     ud: ?*bool,
                     _: *xev.Loop,
                     _: *xev.Completion,
-                    _: Self,
-                    r: Self.CloseError!void,
+                    _: Impl,
+                    r: xev.CloseError!void,
                 ) xev.CallbackAction {
                     _ = r catch unreachable;
                     ud.?.* = false;

--- a/src/watcher/timer.zig
+++ b/src/watcher/timer.zig
@@ -226,20 +226,20 @@ fn TimerLoop(comptime xev: type) type {
     };
 }
 
-fn TimerDynamic(comptime dynamic: type) type {
+fn TimerDynamic(comptime xev: type) type {
     return struct {
         const Self = @This();
 
         backend: Union,
 
-        pub const Union = dynamic.Union(&.{"Timer"});
-        pub const RunError = dynamic.ErrorSet(&.{ "Timer", "RunError" });
-        pub const CancelError = dynamic.ErrorSet(&.{ "Timer", "CancelError" });
+        pub const Union = xev.Union(&.{"Timer"});
+        pub const RunError = xev.ErrorSet(&.{ "Timer", "RunError" });
+        pub const CancelError = xev.ErrorSet(&.{ "Timer", "CancelError" });
 
         pub fn init() !Self {
-            return .{ .backend = switch (dynamic.backend) {
+            return .{ .backend = switch (xev.backend) {
                 inline else => |tag| backend: {
-                    const api = (comptime dynamic.superset(tag)).Api();
+                    const api = (comptime xev.superset(tag)).Api();
                     break :backend @unionInit(
                         Union,
                         @tagName(tag),
@@ -250,7 +250,7 @@ fn TimerDynamic(comptime dynamic: type) type {
         }
 
         pub fn deinit(self: *Self) void {
-            switch (dynamic.backend) {
+            switch (xev.backend) {
                 inline else => |tag| @field(
                     self.backend,
                     @tagName(tag),
@@ -260,38 +260,38 @@ fn TimerDynamic(comptime dynamic: type) type {
 
         pub fn run(
             self: Self,
-            loop: *dynamic.Loop,
-            c: *dynamic.Completion,
+            loop: *xev.Loop,
+            c: *xev.Completion,
             next_ms: u64,
             comptime Userdata: type,
             userdata: ?*Userdata,
             comptime cb: *const fn (
                 ud: ?*Userdata,
-                l: *dynamic.Loop,
-                c: *dynamic.Completion,
+                l: *xev.Loop,
+                c: *xev.Completion,
                 r: RunError!void,
-            ) dynamic.CallbackAction,
+            ) xev.CallbackAction,
         ) void {
-            switch (dynamic.backend) {
+            switch (xev.backend) {
                 inline else => |tag| {
                     c.ensureTag(tag);
 
-                    const api = (comptime dynamic.superset(tag)).Api();
+                    const api = (comptime xev.superset(tag)).Api();
                     const api_cb = (struct {
                         fn callback(
                             ud_inner: ?*Userdata,
                             l_inner: *api.Loop,
                             c_inner: *api.Completion,
                             r_inner: api.Timer.RunError!void,
-                        ) dynamic.CallbackAction {
+                        ) xev.CallbackAction {
                             return cb(
                                 ud_inner,
                                 @fieldParentPtr("backend", @as(
-                                    *dynamic.Loop.Union,
+                                    *xev.Loop.Union,
                                     @fieldParentPtr(@tagName(tag), l_inner),
                                 )),
                                 @fieldParentPtr("value", @as(
-                                    *dynamic.Completion.Union,
+                                    *xev.Completion.Union,
                                     @fieldParentPtr(@tagName(tag), c_inner),
                                 )),
                                 r_inner,
@@ -316,40 +316,40 @@ fn TimerDynamic(comptime dynamic: type) type {
 
         pub fn reset(
             self: Self,
-            loop: *dynamic.Loop,
-            c: *dynamic.Completion,
-            c_cancel: *dynamic.Completion,
+            loop: *xev.Loop,
+            c: *xev.Completion,
+            c_cancel: *xev.Completion,
             next_ms: u64,
             comptime Userdata: type,
             userdata: ?*Userdata,
             comptime cb: *const fn (
                 ud: ?*Userdata,
-                l: *dynamic.Loop,
-                c: *dynamic.Completion,
+                l: *xev.Loop,
+                c: *xev.Completion,
                 r: RunError!void,
-            ) dynamic.CallbackAction,
+            ) xev.CallbackAction,
         ) void {
-            switch (dynamic.backend) {
+            switch (xev.backend) {
                 inline else => |tag| {
                     c.ensureTag(tag);
                     c_cancel.ensureTag(tag);
 
-                    const api = (comptime dynamic.superset(tag)).Api();
+                    const api = (comptime xev.superset(tag)).Api();
                     const api_cb = (struct {
                         fn callback(
                             ud_inner: ?*Userdata,
                             l_inner: *api.Loop,
                             c_inner: *api.Completion,
                             r_inner: api.Timer.RunError!void,
-                        ) dynamic.CallbackAction {
+                        ) xev.CallbackAction {
                             return cb(
                                 ud_inner,
                                 @fieldParentPtr("backend", @as(
-                                    *dynamic.Loop.Union,
+                                    *xev.Loop.Union,
                                     @fieldParentPtr(@tagName(tag), l_inner),
                                 )),
                                 @fieldParentPtr("value", @as(
-                                    *dynamic.Completion.Union,
+                                    *xev.Completion.Union,
                                     @fieldParentPtr(@tagName(tag), c_inner),
                                 )),
                                 r_inner,
@@ -375,39 +375,39 @@ fn TimerDynamic(comptime dynamic: type) type {
 
         pub fn cancel(
             self: Self,
-            loop: *dynamic.Loop,
-            c_timer: *dynamic.Completion,
-            c_cancel: *dynamic.Completion,
+            loop: *xev.Loop,
+            c_timer: *xev.Completion,
+            c_cancel: *xev.Completion,
             comptime Userdata: type,
             userdata: ?*Userdata,
             comptime cb: *const fn (
                 ud: ?*Userdata,
-                l: *dynamic.Loop,
-                c: *dynamic.Completion,
+                l: *xev.Loop,
+                c: *xev.Completion,
                 r: CancelError!void,
-            ) dynamic.CallbackAction,
+            ) xev.CallbackAction,
         ) void {
-            switch (dynamic.backend) {
+            switch (xev.backend) {
                 inline else => |tag| {
                     c_timer.ensureTag(tag);
                     c_cancel.ensureTag(tag);
 
-                    const api = (comptime dynamic.superset(tag)).Api();
+                    const api = (comptime xev.superset(tag)).Api();
                     const api_cb = (struct {
                         fn callback(
                             ud_inner: ?*Userdata,
                             l_inner: *api.Loop,
                             c_inner: *api.Completion,
                             r_inner: api.Timer.CancelError!void,
-                        ) dynamic.CallbackAction {
+                        ) xev.CallbackAction {
                             return cb(
                                 ud_inner,
                                 @fieldParentPtr("backend", @as(
-                                    *dynamic.Loop.Union,
+                                    *xev.Loop.Union,
                                     @fieldParentPtr(@tagName(tag), l_inner),
                                 )),
                                 @fieldParentPtr("value", @as(
-                                    *dynamic.Completion.Union,
+                                    *xev.Completion.Union,
                                     @fieldParentPtr(@tagName(tag), c_inner),
                                 )),
                                 r_inner,
@@ -432,7 +432,7 @@ fn TimerDynamic(comptime dynamic: type) type {
 
         test {
             _ = TimerTests(
-                dynamic,
+                xev,
                 Self,
             );
         }

--- a/src/watcher/timer.zig
+++ b/src/watcher/timer.zig
@@ -232,7 +232,7 @@ fn TimerDynamic(comptime dynamic: type) type {
 
         backend: Union,
 
-        pub const Union = dynamic.Union("Timer");
+        pub const Union = dynamic.Union(&.{"Timer"});
         pub const RunError = dynamic.ErrorSet(&.{ "Timer", "RunError" });
         pub const CancelError = dynamic.ErrorSet(&.{ "Timer", "CancelError" });
 

--- a/src/watcher/timer.zig
+++ b/src/watcher/timer.zig
@@ -214,13 +214,24 @@ pub fn Timer(comptime xev: type) type {
 
         pub const CancelError = xev.CancelError;
 
+        test {
+            _ = TimerTests(xev, Self);
+        }
+    };
+}
+
+pub fn TimerTests(
+    comptime xev: type,
+    comptime Impl: type,
+) type {
+    return struct {
         test "timer" {
             const testing = std.testing;
 
             var loop = try xev.Loop.init(.{});
             defer loop.deinit();
 
-            var timer = try init();
+            var timer = try Impl.init();
             defer timer.deinit();
 
             // Add the timer
@@ -231,7 +242,7 @@ pub fn Timer(comptime xev: type) type {
                     ud: ?*bool,
                     _: *xev.Loop,
                     _: *xev.Completion,
-                    r: RunError!void,
+                    r: Impl.RunError!void,
                 ) xev.CallbackAction {
                     _ = r catch unreachable;
                     ud.?.* = true;
@@ -250,7 +261,7 @@ pub fn Timer(comptime xev: type) type {
             var loop = try xev.Loop.init(.{});
             defer loop.deinit();
 
-            var timer = try init();
+            var timer = try Impl.init();
             defer timer.deinit();
 
             var c_timer: xev.Completion = .{};
@@ -260,7 +271,7 @@ pub fn Timer(comptime xev: type) type {
                     ud: ?*bool,
                     _: *xev.Loop,
                     _: *xev.Completion,
-                    r: RunError!void,
+                    r: Impl.RunError!void,
                 ) xev.CallbackAction {
                     _ = r catch unreachable;
                     ud.?.* = true;
@@ -291,7 +302,7 @@ pub fn Timer(comptime xev: type) type {
             var loop = try xev.Loop.init(.{});
             defer loop.deinit();
 
-            var timer = try init();
+            var timer = try Impl.init();
             defer timer.deinit();
 
             var c_timer: xev.Completion = .{};
@@ -301,7 +312,7 @@ pub fn Timer(comptime xev: type) type {
                     ud: ?*bool,
                     _: *xev.Loop,
                     _: *xev.Completion,
-                    r: RunError!void,
+                    r: Impl.RunError!void,
                 ) xev.CallbackAction {
                     _ = r catch unreachable;
                     ud.?.* = true;
@@ -328,7 +339,7 @@ pub fn Timer(comptime xev: type) type {
             var loop = try xev.Loop.init(.{});
             defer loop.deinit();
 
-            var timer = try init();
+            var timer = try Impl.init();
             defer timer.deinit();
 
             var c_timer: xev.Completion = .{};
@@ -338,7 +349,7 @@ pub fn Timer(comptime xev: type) type {
                     ud: ?*bool,
                     _: *xev.Loop,
                     _: *xev.Completion,
-                    r: RunError!void,
+                    r: Impl.RunError!void,
                 ) xev.CallbackAction {
                     _ = r catch unreachable;
                     ud.?.* = true;
@@ -368,7 +379,7 @@ pub fn Timer(comptime xev: type) type {
             var loop = try xev.Loop.init(.{});
             defer loop.deinit();
 
-            var timer = try init();
+            var timer = try Impl.init();
             defer timer.deinit();
 
             // Add the timer
@@ -379,7 +390,7 @@ pub fn Timer(comptime xev: type) type {
                     ud: ?*bool,
                     _: *xev.Loop,
                     _: *xev.Completion,
-                    r: RunError!void,
+                    r: Impl.RunError!void,
                 ) xev.CallbackAction {
                     ud.?.* = if (r) false else |err| err == error.Canceled;
                     return .disarm;
@@ -394,7 +405,7 @@ pub fn Timer(comptime xev: type) type {
                     ud: ?*bool,
                     _: *xev.Loop,
                     _: *xev.Completion,
-                    r: CancelError!void,
+                    r: Impl.CancelError!void,
                 ) xev.CallbackAction {
                     _ = r catch unreachable;
                     ud.?.* = true;

--- a/src/watcher/udp.zig
+++ b/src/watcher/udp.zig
@@ -752,7 +752,7 @@ fn UDPTests(comptime xev: type, comptime Impl: type) type {
                     _: *xev.Loop,
                     _: *xev.Completion,
                     _: Impl,
-                    r: Impl.CloseError!void,
+                    r: xev.CloseError!void,
                 ) xev.CallbackAction {
                     _ = r catch unreachable;
                     return .disarm;
@@ -764,7 +764,7 @@ fn UDPTests(comptime xev: type, comptime Impl: type) type {
                     _: *xev.Loop,
                     _: *xev.Completion,
                     _: Impl,
-                    r: Impl.CloseError!void,
+                    r: xev.CloseError!void,
                 ) xev.CallbackAction {
                     _ = r catch unreachable;
                     return .disarm;

--- a/src/watcher/udp.zig
+++ b/src/watcher/udp.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const assert = std.debug.assert;
 const posix = std.posix;
 const stream = @import("stream.zig");
@@ -14,6 +15,8 @@ const ThreadPool = @import("../ThreadPool.zig");
 /// if you have specific needs or want to push for the most optimal performance,
 /// use the platform-specific Loop directly.
 pub fn UDP(comptime xev: type) type {
+    if (xev.dynamic) return UDPDynamic(xev);
+
     return switch (xev.backend) {
         // Supported, uses sendmsg/recvmsg exclusively
         .io_uring,
@@ -97,7 +100,7 @@ fn UDPSendto(comptime xev: type) type {
                 addr: std.net.Address,
                 s: Self,
                 b: xev.ReadBuffer,
-                r: ReadError!usize,
+                r: xev.ReadError!usize,
             ) xev.CallbackAction,
         ) void {
             s.* = .{
@@ -160,7 +163,7 @@ fn UDPSendto(comptime xev: type) type {
                 s: *State,
                 s: Self,
                 b: xev.WriteBuffer,
-                r: WriteError!usize,
+                r: xev.WriteError!usize,
             ) xev.CallbackAction,
         ) void {
             s.* = .{
@@ -204,11 +207,9 @@ fn UDPSendto(comptime xev: type) type {
             }
         }
 
-        pub const ReadError = xev.ReadError;
-        pub const WriteError = xev.WriteError;
-
-        /// Common tests
-        pub usingnamespace UDPTests(xev, Self);
+        test {
+            _ = UDPTests(xev, Self);
+        }
     };
 }
 
@@ -279,7 +280,7 @@ fn UDPSendtoIOCP(comptime xev: type) type {
                 addr: std.net.Address,
                 s: Self,
                 b: xev.ReadBuffer,
-                r: ReadError!usize,
+                r: xev.ReadError!usize,
             ) xev.CallbackAction,
         ) void {
             s.* = .{
@@ -342,7 +343,7 @@ fn UDPSendtoIOCP(comptime xev: type) type {
                 s: *State,
                 s: Self,
                 b: xev.WriteBuffer,
-                r: WriteError!usize,
+                r: xev.WriteError!usize,
             ) xev.CallbackAction,
         ) void {
             s.* = .{
@@ -386,11 +387,9 @@ fn UDPSendtoIOCP(comptime xev: type) type {
             }
         }
 
-        pub const ReadError = xev.ReadError;
-        pub const WriteError = xev.WriteError;
-
-        /// Common tests
-        pub usingnamespace UDPTests(xev, Self);
+        test {
+            _ = UDPTests(xev, Self);
+        }
     };
 }
 
@@ -482,7 +481,7 @@ fn UDPSendMsg(comptime xev: type) type {
                 addr: std.net.Address,
                 s: Self,
                 b: xev.ReadBuffer,
-                r: ReadError!usize,
+                r: xev.ReadError!usize,
             ) xev.CallbackAction,
         ) void {
             s.op = .{ .recv = undefined };
@@ -585,7 +584,7 @@ fn UDPSendMsg(comptime xev: type) type {
                 s: *State,
                 s: Self,
                 b: xev.WriteBuffer,
-                r: WriteError!usize,
+                r: xev.WriteError!usize,
             ) xev.CallbackAction,
         ) void {
             // Set the active field for runtime safety
@@ -676,11 +675,227 @@ fn UDPSendMsg(comptime xev: type) type {
             loop.add(c);
         }
 
-        pub const ReadError = xev.ReadError;
-        pub const WriteError = xev.WriteError;
+        test {
+            _ = UDPTests(xev, Self);
+        }
+    };
+}
 
-        /// Common tests
-        pub usingnamespace UDPTests(xev, Self);
+fn UDPDynamic(comptime xev: type) type {
+    return struct {
+        const Self = @This();
+        const FdType = if (builtin.os.tag == .windows)
+            std.os.windows.HANDLE
+        else
+            posix.socket_t;
+
+        backend: Union,
+
+        pub const Union = xev.Union(&.{"UDP"});
+        pub const State = xev.Union(&.{ "UDP", "State" });
+
+        pub usingnamespace stream.Stream(xev, Self, .{
+            .close = true,
+            .poll = true,
+            .read = .none,
+            .write = .none,
+            .type = "UDP",
+        });
+
+        pub fn init(addr: std.net.Address) !Self {
+            return .{ .backend = switch (xev.backend) {
+                inline else => |tag| backend: {
+                    const api = (comptime xev.superset(tag)).Api();
+                    break :backend @unionInit(
+                        Union,
+                        @tagName(tag),
+                        try api.UDP.init(addr),
+                    );
+                },
+            } };
+        }
+
+        pub fn initFd(fdvalue: std.posix.pid_t) Self {
+            return .{ .backend = switch (xev.backend) {
+                inline else => |tag| backend: {
+                    const api = (comptime xev.superset(tag)).Api();
+                    break :backend @unionInit(
+                        Union,
+                        @tagName(tag),
+                        api.UDP.initFd(fdvalue),
+                    );
+                },
+            } };
+        }
+
+        pub fn bind(self: Self, addr: std.net.Address) !void {
+            switch (xev.backend) {
+                inline else => |tag| try @field(
+                    self.backend,
+                    @tagName(tag),
+                ).bind(addr),
+            }
+        }
+
+        pub fn fd(self: Self) FdType {
+            switch (xev.backend) {
+                inline else => |tag| return @field(
+                    self.backend,
+                    @tagName(tag),
+                ).fd,
+            }
+        }
+
+        pub fn read(
+            self: Self,
+            loop: *xev.Loop,
+            c: *xev.Completion,
+            s: *State,
+            buf: xev.ReadBuffer,
+            comptime Userdata: type,
+            userdata: ?*Userdata,
+            comptime cb: *const fn (
+                ud: ?*Userdata,
+                l: *xev.Loop,
+                c: *xev.Completion,
+                s: *State,
+                addr: std.net.Address,
+                s: Self,
+                b: xev.ReadBuffer,
+                r: xev.ReadError!usize,
+            ) xev.CallbackAction,
+        ) void {
+            switch (xev.backend) {
+                inline else => |tag| {
+                    const api = (comptime xev.superset(tag)).Api();
+                    const api_cb = (struct {
+                        fn callback(
+                            ud_inner: ?*Userdata,
+                            l_inner: *api.Loop,
+                            c_inner: *api.Completion,
+                            st_inner: *api.UDP.State,
+                            addr_inner: std.net.Address,
+                            s_inner: api.UDP,
+                            b_inner: api.ReadBuffer,
+                            r_inner: api.ReadError!usize,
+                        ) xev.CallbackAction {
+                            return cb(
+                                ud_inner,
+                                @fieldParentPtr("backend", @as(
+                                    *xev.Loop.Union,
+                                    @fieldParentPtr(@tagName(tag), l_inner),
+                                )),
+                                @fieldParentPtr("value", @as(
+                                    *xev.Completion.Union,
+                                    @fieldParentPtr(@tagName(tag), c_inner),
+                                )),
+                                @fieldParentPtr(
+                                    @tagName(tag),
+                                    st_inner,
+                                ),
+                                addr_inner,
+                                Self.initFd(s_inner.fd),
+                                xev.ReadBuffer.fromBackend(tag, b_inner),
+                                r_inner,
+                            );
+                        }
+                    }).callback;
+
+                    c.ensureTag(tag);
+                    s.* = @unionInit(State, @tagName(tag), undefined);
+
+                    @field(
+                        self.backend,
+                        @tagName(tag),
+                    ).read(
+                        &@field(loop.backend, @tagName(tag)),
+                        &@field(c.value, @tagName(tag)),
+                        &@field(s, @tagName(tag)),
+                        buf.toBackend(tag),
+                        Userdata,
+                        userdata,
+                        api_cb,
+                    );
+                },
+            }
+        }
+
+        pub fn write(
+            self: Self,
+            loop: *xev.Loop,
+            c: *xev.Completion,
+            s: *State,
+            addr: std.net.Address,
+            buf: xev.WriteBuffer,
+            comptime Userdata: type,
+            userdata: ?*Userdata,
+            comptime cb: *const fn (
+                ud: ?*Userdata,
+                l: *xev.Loop,
+                c: *xev.Completion,
+                s: *State,
+                s: Self,
+                b: xev.WriteBuffer,
+                r: xev.WriteError!usize,
+            ) xev.CallbackAction,
+        ) void {
+            switch (xev.backend) {
+                inline else => |tag| {
+                    const api = (comptime xev.superset(tag)).Api();
+                    const api_cb = (struct {
+                        fn callback(
+                            ud_inner: ?*Userdata,
+                            l_inner: *api.Loop,
+                            c_inner: *api.Completion,
+                            st_inner: *api.UDP.State,
+                            s_inner: api.UDP,
+                            b_inner: api.WriteBuffer,
+                            r_inner: api.WriteError!usize,
+                        ) xev.CallbackAction {
+                            return cb(
+                                ud_inner,
+                                @fieldParentPtr("backend", @as(
+                                    *xev.Loop.Union,
+                                    @fieldParentPtr(@tagName(tag), l_inner),
+                                )),
+                                @fieldParentPtr("value", @as(
+                                    *xev.Completion.Union,
+                                    @fieldParentPtr(@tagName(tag), c_inner),
+                                )),
+                                @fieldParentPtr(
+                                    @tagName(tag),
+                                    st_inner,
+                                ),
+                                Self.initFd(s_inner.fd),
+                                xev.WriteBuffer.fromBackend(tag, b_inner),
+                                r_inner,
+                            );
+                        }
+                    }).callback;
+
+                    c.ensureTag(tag);
+                    s.* = @unionInit(State, @tagName(tag), undefined);
+
+                    @field(
+                        self.backend,
+                        @tagName(tag),
+                    ).write(
+                        &@field(loop.backend, @tagName(tag)),
+                        &@field(c.value, @tagName(tag)),
+                        &@field(s, @tagName(tag)),
+                        addr,
+                        buf.toBackend(tag),
+                        Userdata,
+                        userdata,
+                        api_cb,
+                    );
+                },
+            }
+        }
+
+        test {
+            _ = UDPTests(xev, Self);
+        }
     };
 }
 
@@ -714,7 +929,7 @@ fn UDPTests(comptime xev: type, comptime Impl: type) type {
                     _: std.net.Address,
                     _: Impl,
                     _: xev.ReadBuffer,
-                    r: Impl.ReadError!usize,
+                    r: xev.ReadError!usize,
                 ) xev.CallbackAction {
                     ud.?.* = r catch unreachable;
                     return .disarm;
@@ -733,7 +948,7 @@ fn UDPTests(comptime xev: type, comptime Impl: type) type {
                     _: *Impl.State,
                     _: Impl,
                     _: xev.WriteBuffer,
-                    r: Impl.WriteError!usize,
+                    r: xev.WriteError!usize,
                 ) xev.CallbackAction {
                     _ = r catch unreachable;
                     return .disarm;


### PR DESCRIPTION
Fixes #131 

This introduces a new `xev.Dynamic` that mimics the `xev.IO_Uring`, `xev.Epoll`, etc. APIs but chooses an available API at runtime (and also supports manually setting the backend at runtime). There is also a new `xev.DynamicXev()` function that can be used at comptime to create different backend fallbacks. 

The API is identical to `xev` (top-level), `xev.Epoll`, etc. To use it, callers just need to replace their import:

```zig
// From:
const xev = @import("xev");

// To:
const xev = @import("xev").Dynamic;
```

Callers should also call `detect` early in their program before anything runs:

```
try xev.detect();
```

Or they can manually set it:

```
xev.backend = .epoll;
```

Given the runtime dispatch, there is a small performance hit, but given the benchmarks, its negligible: 

```
## Static

info: async1: 3.85 seconds (25974.39/sec)
info: async2: 3.77 seconds (26543.82/sec)
info: async4: 3.59 seconds (27837.56/sec)
info: async8: 3.52 seconds (28437.08/sec)
info: async_pummel_1: 1000000 callbacks in 0.31 seconds (3237817.20/sec)
info: async_pummel_2: 1000000 callbacks in 0.46 seconds (2157493.11/sec)
info: async_pummel_4: 1000000 callbacks in 0.83 seconds (1211627.05/sec)
info: async_pummel_8: 1000000 callbacks in 1.43 seconds (698269.07/sec)

timers:
info: 10.00 seconds total
info: 0.23 seconds init
info: 9.77 seconds dispatch
info: 0.00 seconds cleanup

Ping-pongs:
info: 27631.21 roundtrips/s
info: 18.10 seconds total

info: ping_pongs: 1 pingers, ~716888 roundtrips/s
info: udp_pummel_1v1: 708041f/s received, 708040f/s sent, 1000001 received, 1000000 sent in 1.4 seconds

## Dynamic

info: async1: 3.73 seconds (26788.04/sec)
info: async1: 3.84 seconds (26033.06/sec)
info: async2: 3.80 seconds (26317.92/sec)
info: async2: 3.82 seconds (26152.52/sec)
info: async4: 3.77 seconds (26507.44/sec)
info: async8: 3.66 seconds (27327.84/sec)

info: async_pummel_1: 1000000 callbacks in 0.32 seconds (3167606.15/sec)
info: async_pummel_2: 1000000 callbacks in 0.41 seconds (2435983.01/sec)
info: async_pummel_4: 1000000 callbacks in 0.52 seconds (1929071.52/sec)
info: async_pummel_8: 1000000 callbacks in 0.85 seconds (1179432.21/sec)

Timer:
info: 10.00 seconds total
info: 0.49 seconds init
info: 9.51 seconds dispatch
info: 0.00 seconds cleanup

Ping-pongs:
info: 26716.33 roundtrips/s
info: 18.72 seconds total

info: ping_pongs: 1 pingers, ~717047 roundtrips/s
info: udp_pummel_1v1: 725060f/s received, 725059f/s sent, 1000001 received, 1000000 sent in 1.4 seconds
```