### PR TITLE
errors!: s/ConnectionReset/ConnectionResetByPeer/g

### DIFF
--- a/src/backend/io_uring.zig
+++ b/src/backend/io_uring.zig
@@ -709,7 +709,7 @@ pub const Completion = struct {
                 else switch (@as(posix.E, @enumFromInt(-res))) {
                     .CANCELED => error.Canceled,
                     .PIPE => error.BrokenPipe,
-                    .CONNRESET => error.ConnectionReset,
+                    .CONNRESET => error.ConnectionResetByPeer,
                     else => |errno| posix.unexpectedErrno(errno),
                 },
             },
@@ -720,7 +720,7 @@ pub const Completion = struct {
                 else switch (@as(posix.E, @enumFromInt(-res))) {
                     .CANCELED => error.Canceled,
                     .PIPE => error.BrokenPipe,
-                    .CONNRESET => error.ConnectionReset,
+                    .CONNRESET => error.ConnectionResetByPeer,
                     else => |errno| posix.unexpectedErrno(errno),
                 },
             },
@@ -819,7 +819,7 @@ pub const Completion = struct {
 
         return switch (@as(posix.E, @enumFromInt(-res))) {
             .CANCELED => error.Canceled,
-            .CONNRESET => error.ConnectionReset,
+            .CONNRESET => error.ConnectionResetByPeer,
             else => |errno| posix.unexpectedErrno(errno),
         };
     }
@@ -1074,7 +1074,7 @@ pub const ReadError = error{
     EOF,
     Canceled,
     Unexpected,
-    ConnectionReset,
+    ConnectionResetByPeer,
 };
 
 pub const ShutdownError = error{
@@ -1085,7 +1085,7 @@ pub const ShutdownError = error{
 pub const WriteError = error{
     Canceled,
     BrokenPipe,
-    ConnectionReset,
+    ConnectionResetByPeer,
     Unexpected,
 };
 

--- a/src/backend/iocp.zig
+++ b/src/backend/iocp.zig
@@ -624,7 +624,7 @@ pub const Loop = struct {
                     break :action switch (err) {
                         windows.ws2_32.WinsockError.WSA_IO_PENDING => .{ .submitted = {} },
                         .WSA_OPERATION_ABORTED, .WSAECONNABORTED => .{ .result = .{ .send = error.Canceled } },
-                        .WSAECONNRESET, .WSAENETRESET => .{ .result = .{ .send = error.ConnectionReset } },
+                        .WSAECONNRESET, .WSAENETRESET => .{ .result = .{ .send = error.ConnectionResetByPeer } },
                         else => .{ .result = .{ .send = windows.unexpectedWSAError(err) } },
                     };
                 }
@@ -652,7 +652,7 @@ pub const Loop = struct {
                     break :action switch (err) {
                         windows.ws2_32.WinsockError.WSA_IO_PENDING => .{ .submitted = {} },
                         .WSA_OPERATION_ABORTED, .WSAECONNABORTED => .{ .result = .{ .recv = error.Canceled } },
-                        .WSAECONNRESET, .WSAENETRESET => .{ .result = .{ .recv = error.ConnectionReset } },
+                        .WSAECONNRESET, .WSAENETRESET => .{ .result = .{ .recv = error.ConnectionResetByPeer } },
                         else => .{ .result = .{ .recv = windows.unexpectedWSAError(err) } },
                     };
                 }
@@ -679,7 +679,7 @@ pub const Loop = struct {
                     break :action switch (err) {
                         windows.ws2_32.WinsockError.WSA_IO_PENDING => .{ .submitted = {} },
                         .WSA_OPERATION_ABORTED, .WSAECONNABORTED => .{ .result = .{ .sendto = error.Canceled } },
-                        .WSAECONNRESET, .WSAENETRESET => .{ .result = .{ .sendto = error.ConnectionReset } },
+                        .WSAECONNRESET, .WSAENETRESET => .{ .result = .{ .sendto = error.ConnectionResetByPeer } },
                         else => .{ .result = .{ .sendto = windows.unexpectedWSAError(err) } },
                     };
                 }
@@ -709,7 +709,7 @@ pub const Loop = struct {
                     break :action switch (err) {
                         windows.ws2_32.WinsockError.WSA_IO_PENDING => .{ .submitted = {} },
                         .WSA_OPERATION_ABORTED, .WSAECONNABORTED => .{ .result = .{ .recvfrom = error.Canceled } },
-                        .WSAECONNRESET, .WSAENETRESET => .{ .result = .{ .recvfrom = error.ConnectionReset } },
+                        .WSAECONNRESET, .WSAENETRESET => .{ .result = .{ .recvfrom = error.ConnectionResetByPeer } },
                         else => .{ .result = .{ .recvfrom = windows.unexpectedWSAError(err) } },
                     };
                 }
@@ -1049,7 +1049,7 @@ pub const Completion = struct {
                     break :r .{
                         .send = switch (err) {
                             .WSA_OPERATION_ABORTED, .WSAECONNABORTED => error.Canceled,
-                            .WSAECONNRESET, .WSAENETRESET => error.ConnectionReset,
+                            .WSAECONNRESET, .WSAENETRESET => error.ConnectionResetByPeer,
                             else => windows.unexpectedWSAError(err),
                         },
                     };
@@ -1068,7 +1068,7 @@ pub const Completion = struct {
                     break :r .{
                         .recv = switch (err) {
                             .WSA_OPERATION_ABORTED, .WSAECONNABORTED => error.Canceled,
-                            .WSAECONNRESET, .WSAENETRESET => error.ConnectionReset,
+                            .WSAECONNRESET, .WSAENETRESET => error.ConnectionResetByPeer,
                             else => windows.unexpectedWSAError(err),
                         },
                     };
@@ -1103,7 +1103,7 @@ pub const Completion = struct {
                     break :r .{
                         .sendto = switch (err) {
                             .WSA_OPERATION_ABORTED, .WSAECONNABORTED => error.Canceled,
-                            .WSAECONNRESET, .WSAENETRESET => error.ConnectionReset,
+                            .WSAECONNRESET, .WSAENETRESET => error.ConnectionResetByPeer,
                             else => windows.unexpectedWSAError(err),
                         },
                     };
@@ -1122,7 +1122,7 @@ pub const Completion = struct {
                     break :r .{
                         .recvfrom = switch (err) {
                             .WSA_OPERATION_ABORTED, .WSAECONNABORTED => error.Canceled,
-                            .WSAECONNRESET, .WSAENETRESET => error.ConnectionReset,
+                            .WSAECONNRESET, .WSAENETRESET => error.ConnectionResetByPeer,
                             else => windows.unexpectedWSAError(err),
                         },
                     };
@@ -1351,14 +1351,14 @@ pub const ShutdownError = posix.ShutdownError || error{
 
 pub const WriteError = windows.WriteFileError || error{
     Canceled,
-    ConnectionReset,
+    ConnectionResetByPeer,
     Unexpected,
 };
 
 pub const ReadError = windows.ReadFileError || error{
     EOF,
     Canceled,
-    ConnectionReset,
+    ConnectionResetByPeer,
     Unexpected,
 };
 


### PR DESCRIPTION
The kqueue and epoll backends forward errors from zig. The zig error
name for a Connection Reset is ConnectionResetByPeer. Use this name for
libxev defined errors which semantically mean the same thing. This
prevents users of the library from needing to check the backend before
handling a ConnectionResetByPeer error.
