### PR TITLE
File: Fix wrong FileStream.deinit signature

### DIFF
--- a/src/watcher/file.zig
+++ b/src/watcher/file.zig
@@ -63,7 +63,7 @@ fn FileStream(comptime xev: type) type {
         /// Clean up any watcher resources. This does NOT close the file.
         /// If you want to close the file you must call close or do so
         /// synchronously.
-        pub fn deinit(self: *const File) void {
+        pub fn deinit(self: *const Self) void {
             _ = self;
         }
 


### PR DESCRIPTION
File is a fn , not a type. Calling `deinit` (although there's no reason to do that) produces a compile error:

```
/home/bob/.cache/zig/p/libxev-0.0.0-86vtc-zkEgB7uv1i0Sa6ytJETZQi_lHJrImu9mLb9moi/src/watcher/file.zig:66:36: error: expected type 'type', found 'fn (comptime type) type'
        pub fn deinit(self: *const File) void {
```

Not at all an actual issue. But will confuse new users when they try to call `deinit` and get a surprising type error