### PR TITLE
Swap read on timerfd/eventfd to poll to avoid Kernel 6.15.4 bug

### DIFF
--- a/src/backend/io_uring.zig
+++ b/src/backend/io_uring.zig
@@ -1182,9 +1182,12 @@ test "io_uring: timerfd" {
     var called = false;
     var c: Completion = .{
         .op = .{
-            .read = .{
+            // Note: we should be able to use `read` here but on
+            // Kernel 6.15.4 there is a bug that prevents the read
+            // from ever firing with io_uring. I don't know why. I changed
+            // this to a poll so tests pass, which should also be fine!
+            .poll = .{
                 .fd = t.fd,
-                .buffer = .{ .array = undefined },
             },
         },
 


### PR DESCRIPTION
This commit changes our operations on timerfd and eventfd from using read to using poll. This is a workaround for a bug in Kernel 6.15.4 that causes read operations on these file descriptors to hang indefinitely.

A poll is equivalent to what we're trying to achieve here and is equivalent to epoll because epoll is already polling and `read` was just a wrapper that subsequently called `read` anyways.

Prior to this commit, tests would hang on 6.15.4, now they pass.