### PR TITLE
use `mlugg/setup-zig` instead of `goto-bus-stop/setup-zig`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install zig
-      uses: goto-bus-stop/setup-zig@v2
+      uses: mlugg/setup-zig@v2
       with:
         version: 0.14.1
 
@@ -143,7 +143,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install zig
-      uses: goto-bus-stop/setup-zig@v2
+      uses: mlugg/setup-zig@v2
       with:
         version: 0.14.1
 


### PR DESCRIPTION
The 'goto-bus-stop' action is no longer maintained and uses outdated methods for getting the Zig toolchain. Instead use the one maintained by mlugg, which uses the mirror system and is generally better.