### PR TITLE
remove usingnamespace from main.zig

### DIFF
--- a/docs/xev-zig.7.scd
+++ b/docs/xev-zig.7.scd
@@ -17,10 +17,7 @@ over the C API. For example, all callbacks in the Zig API must be available
 at comptime because the callback call is always inlined -- this results in
 a noticable performance improvement over equivalent C consumption of libxev.
 
-The primary Zig API is visible in `src/main.zig` in the libxev source. The main file uses a somewhat convoluted `usingnamespace` to setup the
-API so it isn't immediately obvious, but the API is provided by the `Xev`
-function. For example, available consts are: `xev.Loop`, `xev.Completion`,
-etc.
+The primary Zig API is visible in `src/main.zig` in the libxev source. 
 
 # INSTALLATION
 

--- a/src/api.zig
+++ b/src/api.zig
@@ -1,0 +1,88 @@
+const builtin = @import("builtin");
+const stream = @import("watcher/stream.zig");
+const Backend = @import("backend.zig").Backend;
+
+/// Creates the Xev API based on a backend type.
+///
+/// For the default backend type for your system (i.e. io_uring on Linux),
+/// this is the main API you interact with. It is forwarded into the main
+/// the "xev" package so you'd use types such as `xev.Loop`, `xev.Completion`,
+/// etc.
+///
+/// Unless you're using a custom or specific backend type, you do NOT ever
+/// need to call the Xev function itself.
+pub fn Xev(comptime be: Backend, comptime T: type) type {
+    return struct {
+        const Self = @This();
+        const loop = @import("loop.zig");
+
+        /// This is used to detect a static vs dynamic API at comptime.
+        pub const dynamic = false;
+
+        /// The backend that this is. This is supplied at comptime so
+        /// it is up to the caller to say the right thing. This lets custom
+        /// implementations also "quack" like an implementation.
+        pub const backend = be;
+
+        /// A function to test if this API is available on the
+        /// current system.
+        pub const available = T.available;
+
+        /// The core loop APIs.
+        pub const Loop = T.Loop;
+        pub const Completion = T.Completion;
+        pub const Result = T.Result;
+        pub const ReadBuffer = T.ReadBuffer;
+        pub const WriteBuffer = T.WriteBuffer;
+        pub const Options = loop.Options;
+        pub const RunMode = loop.RunMode;
+        pub const CallbackAction = loop.CallbackAction;
+        pub const CompletionState = loop.CompletionState;
+
+        /// Error types
+        pub const AcceptError = T.AcceptError;
+        pub const CancelError = T.CancelError;
+        pub const CloseError = T.CloseError;
+        pub const ConnectError = T.ConnectError;
+        pub const ShutdownError = T.ShutdownError;
+        pub const WriteError = T.WriteError;
+        pub const ReadError = T.ReadError;
+
+        /// Shared stream types
+        const SharedStream = stream.Shared(Self);
+        pub const PollError = SharedStream.PollError;
+        pub const PollEvent = SharedStream.PollEvent;
+        pub const WriteQueue = SharedStream.WriteQueue;
+        pub const WriteRequest = SharedStream.WriteRequest;
+
+        /// The high-level helper interfaces that make it easier to perform
+        /// common tasks. These may not work with all possible Loop implementations.
+        pub const Async = @import("watcher/async.zig").Async(Self);
+        pub const File = @import("watcher/file.zig").File(Self);
+        pub const Process = @import("watcher/process.zig").Process(Self);
+        pub const Stream = stream.GenericStream(Self);
+        pub const Timer = @import("watcher/timer.zig").Timer(Self);
+        pub const TCP = @import("watcher/tcp.zig").TCP(Self);
+        pub const UDP = @import("watcher/udp.zig").UDP(Self);
+
+        /// The callback of the main Loop operations. Higher level interfaces may
+        /// use a different callback mechanism.
+        pub const Callback = loop.Callback(T);
+
+        /// A callback that does nothing and immediately disarms. This
+        /// implements xev.Callback and is the default value for completions.
+        pub const noopCallback = loop.NoopCallback(T);
+
+        /// A way to access the raw type.
+        pub const Sys = T;
+
+        test {
+            @import("std").testing.refAllDecls(@This());
+        }
+
+        test "completion is zero-able" {
+            const c: Self.Completion = .{};
+            _ = c;
+        }
+    };
+}

--- a/src/backend.zig
+++ b/src/backend.zig
@@ -1,0 +1,52 @@
+const builtin = @import("builtin");
+const stream = @import("watcher/stream.zig");
+
+/// The backend types.
+pub const Backend = enum {
+    io_uring,
+    epoll,
+    kqueue,
+    wasi_poll,
+    iocp,
+
+    /// Returns a recommend default backend from inspecting the system.
+    pub fn default() Backend {
+        return switch (builtin.os.tag) {
+            .linux => .io_uring,
+            .ios, .macos => .kqueue,
+            .freebsd => .kqueue,
+            .wasi => .wasi_poll,
+            .windows => .iocp,
+            else => {
+                @compileLog(builtin.os);
+                @compileError("no default backend for this target");
+            },
+        };
+    }
+
+    /// Candidate backends for this platform in priority order.
+    pub fn candidates() []const Backend {
+        return switch (builtin.os.tag) {
+            .linux => &.{ .io_uring, .epoll },
+            .ios, .macos => &.{.kqueue},
+            .freebsd => &.{.kqueue},
+            .wasi => &.{.wasi_poll},
+            .windows => &.{.iocp},
+            else => {
+                @compileLog(builtin.os);
+                @compileError("no candidate backends for this target");
+            },
+        };
+    }
+
+    /// Returns the Api (return value of Xev) for the given backend type.
+    pub fn Api(comptime self: Backend) type {
+        return switch (self) {
+            .io_uring => @import("main.zig").IO_Uring,
+            .epoll => @import("main.zig").Epoll,
+            .kqueue => @import("main.zig").Kqueue,
+            .wasi_poll => @import("main.zig").WasiPoll,
+            .iocp => @import("main.zig").IOCP,
+        };
+    }
+};

--- a/src/backend/io_uring.zig
+++ b/src/backend/io_uring.zig
@@ -4,7 +4,11 @@ const assert = std.debug.assert;
 const linux = std.os.linux;
 const posix = std.posix;
 const queue = @import("../queue.zig");
-const xev = @import("../main.zig").IO_Uring;
+const looppkg = @import("../loop.zig");
+const Callback = looppkg.Callback(@This());
+const CallbackAction = looppkg.CallbackAction;
+const CompletionState = looppkg.CompletionState;
+const noopCallback = looppkg.NoopCallback(@This());
 
 /// True if this backend is available on this platform.
 pub fn available() bool {
@@ -53,7 +57,7 @@ pub const Loop = struct {
     /// submissions that can be queued at one time. The number of completions
     /// always matches the number of entries so the memory allocated will be
     /// 2x entries (plus the basic loop overhead).
-    pub fn init(options: xev.Options) !Loop {
+    pub fn init(options: looppkg.Options) !Loop {
         const entries = std.math.cast(u13, options.entries) orelse
             return error.TooManyEntries;
 
@@ -73,7 +77,7 @@ pub const Loop = struct {
     }
 
     /// Run the event loop. See RunMode documentation for details on modes.
-    pub fn run(self: *Loop, mode: xev.RunMode) !void {
+    pub fn run(self: *Loop, mode: looppkg.RunMode) !void {
         switch (mode) {
             .no_wait => try self.tick_(.no_wait),
             .once => try self.tick_(.once),
@@ -131,7 +135,7 @@ pub const Loop = struct {
 
     /// Tick the loop. The mode is comptime so we can do some tricks to
     /// avoid function calls and runtime branching.
-    fn tick_(self: *Loop, comptime mode: xev.RunMode) !void {
+    fn tick_(self: *Loop, comptime mode: looppkg.RunMode) !void {
         // We can't nest runs.
         if (self.flags.in_run) return error.NestedRunsNotAllowed;
         self.flags.in_run = true;
@@ -243,7 +247,7 @@ pub const Loop = struct {
         c: *Completion,
         next_ms: u64,
         userdata: ?*anyopaque,
-        comptime cb: xev.Callback,
+        comptime cb: Callback,
     ) void {
         c.* = .{
             .op = .{
@@ -283,7 +287,7 @@ pub const Loop = struct {
         c_cancel: *Completion,
         next_ms: u64,
         userdata: ?*anyopaque,
-        comptime cb: xev.Callback,
+        comptime cb: Callback,
     ) void {
         if (c.state() == .dead) {
             self.timer(c, next_ms, userdata, cb);
@@ -566,10 +570,10 @@ pub const Loop = struct {
         userdata: ?*Userdata,
         comptime cb: *const fn (
             ud: ?*Userdata,
-            l: *xev.Loop,
-            c: *xev.Completion,
+            l: *Loop,
+            c: *Completion,
             r: CancelError!void,
-        ) xev.CallbackAction,
+        ) CallbackAction,
     ) void {
         c_cancel.* = .{
             .op = .{
@@ -581,10 +585,10 @@ pub const Loop = struct {
             .callback = (struct {
                 fn callback(
                     ud: ?*anyopaque,
-                    l_inner: *xev.Loop,
-                    c_inner: *xev.Completion,
-                    r: xev.Result,
-                ) xev.CallbackAction {
+                    l_inner: *Loop,
+                    c_inner: *Completion,
+                    r: Result,
+                ) CallbackAction {
                     return @call(.always_inline, cb, .{
                         @as(?*Userdata, if (Userdata == void) null else @ptrCast(@alignCast(ud))),
                         l_inner,
@@ -613,7 +617,7 @@ pub const Completion = struct {
 
     /// Userdata and callback for when the completion is finished.
     userdata: ?*anyopaque = null,
-    callback: xev.Callback = xev.noopCallback,
+    callback: Callback = noopCallback,
 
     /// Internally set
     next: ?*Completion = null,
@@ -642,7 +646,7 @@ pub const Completion = struct {
     ///
     /// Third, if you stop the loop (loop.stop()), the completions registered
     /// with the loop will NOT be reset to a dead state.
-    pub fn state(self: Completion) xev.CompletionState {
+    pub fn state(self: Completion) CompletionState {
         return switch (self.flags.state) {
             .dead => .dead,
             .active => .active,
@@ -651,7 +655,7 @@ pub const Completion = struct {
 
     /// Invokes the callback for this completion after properly constructing
     /// the Result based on the res code.
-    fn invoke(self: *Completion, loop: *Loop, res: i32) xev.CallbackAction {
+    fn invoke(self: *Completion, loop: *Loop, res: i32) CallbackAction {
         const result: Result = switch (self.op) {
             .noop => unreachable,
 
@@ -1146,7 +1150,7 @@ test "io_uring: default completion" {
     var timer_called = false;
     var c1: Completion = undefined;
     loop.timer(&c1, 1, &timer_called, (struct {
-        fn callback(ud: ?*anyopaque, l: *xev.Loop, _: *xev.Completion, r: xev.Result) xev.CallbackAction {
+        fn callback(ud: ?*anyopaque, l: *Loop, _: *Completion, r: Result) CallbackAction {
             _ = l;
             _ = r;
             const b = @as(*bool, @ptrCast(ud.?));
@@ -1195,10 +1199,10 @@ test "io_uring: timerfd" {
         .callback = (struct {
             fn callback(
                 ud: ?*anyopaque,
-                l: *xev.Loop,
-                c: *xev.Completion,
-                r: xev.Result,
-            ) xev.CallbackAction {
+                l: *Loop,
+                c: *Completion,
+                r: Result,
+            ) CallbackAction {
                 _ = c;
                 _ = r;
                 _ = l;
@@ -1229,7 +1233,7 @@ test "io_uring: timer" {
     var called = false;
     var c1: Completion = undefined;
     loop.timer(&c1, 1, &called, (struct {
-        fn callback(ud: ?*anyopaque, l: *xev.Loop, _: *xev.Completion, r: xev.Result) xev.CallbackAction {
+        fn callback(ud: ?*anyopaque, l: *Loop, _: *Completion, r: Result) CallbackAction {
             _ = l;
             _ = r;
             const b = @as(*bool, @ptrCast(ud.?));
@@ -1242,7 +1246,7 @@ test "io_uring: timer" {
     var called2 = false;
     var c2: Completion = undefined;
     loop.timer(&c2, 100_000, &called2, (struct {
-        fn callback(ud: ?*anyopaque, l: *xev.Loop, _: *xev.Completion, r: xev.Result) xev.CallbackAction {
+        fn callback(ud: ?*anyopaque, l: *Loop, _: *Completion, r: Result) CallbackAction {
             _ = l;
             _ = r;
             const b = @as(*bool, @ptrCast(ud.?));
@@ -1271,13 +1275,13 @@ test "io_uring: timer reset" {
     var loop = try Loop.init(.{});
     defer loop.deinit();
 
-    const cb: xev.Callback = (struct {
+    const cb: Callback = (struct {
         fn callback(
             ud: ?*anyopaque,
-            l: *xev.Loop,
-            _: *xev.Completion,
-            r: xev.Result,
-        ) xev.CallbackAction {
+            l: *Loop,
+            _: *Completion,
+            r: Result,
+        ) CallbackAction {
             _ = l;
             const v = @as(*?TimerTrigger, @ptrCast(ud.?));
             v.* = r.timer catch unreachable;
@@ -1317,7 +1321,7 @@ test "io_uring: stop" {
     var called = false;
     var c1: Completion = undefined;
     loop.timer(&c1, 1_000_000, &called, (struct {
-        fn callback(ud: ?*anyopaque, l: *xev.Loop, _: *xev.Completion, r: xev.Result) xev.CallbackAction {
+        fn callback(ud: ?*anyopaque, l: *Loop, _: *Completion, r: Result) CallbackAction {
             _ = l;
             _ = r;
             const b = @as(*bool, @ptrCast(ud.?));
@@ -1360,7 +1364,7 @@ test "io_uring: timer remove" {
     var trigger: ?TimerTrigger = null;
     var c1: Completion = undefined;
     loop.timer(&c1, 100_000, &trigger, (struct {
-        fn callback(ud: ?*anyopaque, l: *xev.Loop, _: *xev.Completion, r: xev.Result) xev.CallbackAction {
+        fn callback(ud: ?*anyopaque, l: *Loop, _: *Completion, r: Result) CallbackAction {
             _ = l;
             const b = @as(*?TimerTrigger, @ptrCast(ud.?));
             b.* = r.timer catch unreachable;
@@ -1378,7 +1382,7 @@ test "io_uring: timer remove" {
 
         .userdata = null,
         .callback = (struct {
-            fn callback(ud: ?*anyopaque, l: *xev.Loop, c: *xev.Completion, r: xev.Result) xev.CallbackAction {
+            fn callback(ud: ?*anyopaque, l: *Loop, c: *Completion, r: Result) CallbackAction {
                 _ = l;
                 _ = c;
                 _ = ud;
@@ -1427,7 +1431,7 @@ test "io_uring: socket accept/connect/send/recv/close" {
 
         .userdata = &server_conn,
         .callback = (struct {
-            fn callback(ud: ?*anyopaque, l: *xev.Loop, c: *xev.Completion, r: xev.Result) xev.CallbackAction {
+            fn callback(ud: ?*anyopaque, l: *Loop, c: *Completion, r: Result) CallbackAction {
                 _ = l;
                 _ = c;
                 const conn = @as(*os.socket_t, @ptrCast(@alignCast(ud.?)));
@@ -1450,7 +1454,7 @@ test "io_uring: socket accept/connect/send/recv/close" {
 
         .userdata = &connected,
         .callback = (struct {
-            fn callback(ud: ?*anyopaque, l: *xev.Loop, c: *xev.Completion, r: xev.Result) xev.CallbackAction {
+            fn callback(ud: ?*anyopaque, l: *Loop, c: *Completion, r: Result) CallbackAction {
                 _ = l;
                 _ = c;
                 _ = r.connect catch unreachable;
@@ -1477,7 +1481,7 @@ test "io_uring: socket accept/connect/send/recv/close" {
         },
 
         .callback = (struct {
-            fn callback(ud: ?*anyopaque, l: *xev.Loop, c: *xev.Completion, r: xev.Result) xev.CallbackAction {
+            fn callback(ud: ?*anyopaque, l: *Loop, c: *Completion, r: Result) CallbackAction {
                 _ = l;
                 _ = c;
                 _ = r.send catch unreachable;
@@ -1501,7 +1505,7 @@ test "io_uring: socket accept/connect/send/recv/close" {
 
         .userdata = &recv_len,
         .callback = (struct {
-            fn callback(ud: ?*anyopaque, l: *xev.Loop, c: *xev.Completion, r: xev.Result) xev.CallbackAction {
+            fn callback(ud: ?*anyopaque, l: *Loop, c: *Completion, r: Result) CallbackAction {
                 _ = l;
                 _ = c;
                 const ptr = @as(*usize, @ptrCast(@alignCast(ud.?)));
@@ -1527,7 +1531,7 @@ test "io_uring: socket accept/connect/send/recv/close" {
 
         .userdata = &shutdown,
         .callback = (struct {
-            fn callback(ud: ?*anyopaque, l: *xev.Loop, c: *xev.Completion, r: xev.Result) xev.CallbackAction {
+            fn callback(ud: ?*anyopaque, l: *Loop, c: *Completion, r: Result) CallbackAction {
                 _ = l;
                 _ = c;
                 _ = r.shutdown catch unreachable;
@@ -1553,7 +1557,7 @@ test "io_uring: socket accept/connect/send/recv/close" {
 
         .userdata = &eof,
         .callback = (struct {
-            fn callback(ud: ?*anyopaque, l: *xev.Loop, c: *xev.Completion, r: xev.Result) xev.CallbackAction {
+            fn callback(ud: ?*anyopaque, l: *Loop, c: *Completion, r: Result) CallbackAction {
                 _ = l;
                 _ = c;
                 const ptr = @as(*?bool, @ptrCast(@alignCast(ud.?)));
@@ -1580,7 +1584,7 @@ test "io_uring: socket accept/connect/send/recv/close" {
 
         .userdata = &client_conn,
         .callback = (struct {
-            fn callback(ud: ?*anyopaque, l: *xev.Loop, c: *xev.Completion, r: xev.Result) xev.CallbackAction {
+            fn callback(ud: ?*anyopaque, l: *Loop, c: *Completion, r: Result) CallbackAction {
                 _ = l;
                 _ = c;
                 _ = r.close catch unreachable;
@@ -1601,7 +1605,7 @@ test "io_uring: socket accept/connect/send/recv/close" {
 
         .userdata = &ln,
         .callback = (struct {
-            fn callback(ud: ?*anyopaque, l: *xev.Loop, c: *xev.Completion, r: xev.Result) xev.CallbackAction {
+            fn callback(ud: ?*anyopaque, l: *Loop, c: *Completion, r: Result) CallbackAction {
                 _ = l;
                 _ = c;
                 _ = r.close catch unreachable;
@@ -1662,7 +1666,7 @@ test "io_uring: sendmsg/recvmsg" {
         },
 
         .callback = (struct {
-            fn callback(ud: ?*anyopaque, l: *xev.Loop, c: *xev.Completion, r: xev.Result) xev.CallbackAction {
+            fn callback(ud: ?*anyopaque, l: *Loop, c: *Completion, r: Result) CallbackAction {
                 _ = ud;
                 _ = l;
                 _ = c;
@@ -1701,7 +1705,7 @@ test "io_uring: sendmsg/recvmsg" {
 
         .userdata = &recv_size,
         .callback = (struct {
-            fn callback(ud: ?*anyopaque, l: *xev.Loop, c: *xev.Completion, r: xev.Result) xev.CallbackAction {
+            fn callback(ud: ?*anyopaque, l: *Loop, c: *Completion, r: Result) CallbackAction {
                 _ = l;
                 _ = c;
                 const ptr = @as(*usize, @ptrCast(@alignCast(ud.?)));
@@ -1734,7 +1738,7 @@ test "io_uring: socket read cancellation" {
     try posix.bind(socket, &address.any, address.getOsSockLen());
 
     // Read
-    var read_result: xev.Result = undefined;
+    var read_result: Result = undefined;
     var c_read: Completion = .{
         .op = .{
             .read = .{
@@ -1746,8 +1750,8 @@ test "io_uring: socket read cancellation" {
         },
         .userdata = &read_result,
         .callback = (struct {
-            fn callback(ud: ?*anyopaque, l: *xev.Loop, c: *xev.Completion, r: xev.Result) xev.CallbackAction {
-                const ptr = @as(*xev.Result, @ptrCast(@alignCast(ud)));
+            fn callback(ud: ?*anyopaque, l: *Loop, c: *Completion, r: Result) CallbackAction {
+                const ptr = @as(*Result, @ptrCast(@alignCast(ud)));
                 ptr.* = r;
                 _ = c;
                 _ = l;
@@ -1765,7 +1769,7 @@ test "io_uring: socket read cancellation" {
         void,
         null,
         (struct {
-            fn callback(ud: ?*void, l: *xev.Loop, c: *xev.Completion, r: xev.CancelError!void) xev.CallbackAction {
+            fn callback(ud: ?*void, l: *Loop, c: *Completion, r: CancelError!void) CallbackAction {
                 r catch unreachable;
                 _ = c;
                 _ = l;

--- a/src/loop.zig
+++ b/src/loop.zig
@@ -43,6 +43,32 @@ pub const RunMode = enum(c_int) {
     until_done = 2,
 };
 
+/// The callback of the main Loop operations. Higher level interfaces may
+/// use a different callback mechanism.
+pub fn Callback(comptime T: type) type {
+    return *const fn (
+        userdata: ?*anyopaque,
+        loop: *T.Loop,
+        completion: *T.Completion,
+        result: T.Result,
+    ) CallbackAction;
+}
+
+/// A callback that does nothing and immediately disarms. This
+/// implements xev.Callback and is the default value for completions.
+pub fn NoopCallback(comptime T: type) Callback(T) {
+    return (struct {
+        pub fn noopCallback(
+            _: ?*anyopaque,
+            _: *T.Loop,
+            _: *T.Completion,
+            _: T.Result,
+        ) CallbackAction {
+            return .disarm;
+        }
+    }).noopCallback;
+}
+
 /// The result type for callbacks. This should be used by all loop
 /// implementations and higher level abstractions in order to control
 /// what to do after the loop completes.


### PR DESCRIPTION
This should be 100% API compatible, and I wrote a comptime test to help ensure that. Still, I suppose something could slip through.

The major churn in this PR is to avoid a circular dependency when verifying that the API didn't change. We remove the dependency on main.zig from the backends, which is cleaner in general, but it makes for a big diff.