### PR TITLE
fix: wasi32-wasm compatibility

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -104,7 +104,7 @@ pub fn build(b: *std.Build) !void {
 
     // Benchmarks and examples
     const benchmarks = try buildBenchmarks(b, target);
-    const examples = try buildExamples(b, target, optimize, static_lib);
+    const examples = if (emit_examples) try buildExamples(b, target, optimize, static_lib) else null;
 
     // Test Executable
     const test_exe: *Step.Compile = test_exe: {
@@ -150,7 +150,7 @@ pub fn build(b: *std.Build) !void {
             } } },
         ).step);
     };
-    if (emit_examples) for (examples) |exe| {
+    if (examples) |list| for (list) |exe| {
         b.getInstallStep().dependOn(&b.addInstallArtifact(
             exe,
             .{ .dest_dir = .{ .override = .{


### PR DESCRIPTION
Fixes `wasm32-wasi`. Ran into a few issues but the tests run now:
1. `build.zig` was throwing an error because the libs are not emitted on wasm
2. Type errors and general testing issues

To test: `zig build test -Dtarget=wasm32-wasi -fwasmtime`