### PR TITLE
Fix file pread/pwrite on Windows

### DIFF
--- a/src/backend/iocp.zig
+++ b/src/backend/iocp.zig
@@ -1004,8 +1004,9 @@ pub const Completion = struct {
                 if (result == windows.FALSE) {
                     const err = windows.kernel32.GetLastError();
                     return .{
-                        .read = switch (err) {
+                        .pread = switch (err) {
                             windows.Win32Error.OPERATION_ABORTED => error.Canceled,
+                            windows.Win32Error.HANDLE_EOF => error.EOF,
                             else => error.Unexpected,
                         },
                     };
@@ -1034,7 +1035,7 @@ pub const Completion = struct {
                 if (result == windows.FALSE) {
                     const err = windows.kernel32.GetLastError();
                     return .{
-                        .write = switch (err) {
+                        .pwrite = switch (err) {
                             windows.Win32Error.OPERATION_ABORTED => error.Canceled,
                             else => error.Unexpected,
                         },


### PR DESCRIPTION
Also note that read/write for files is completely broken on windows, they need manual offset tracking.