### PR TITLE
replace dead blog post links

### DIFF
--- a/docs/xev_threadpool.3.scd
+++ b/docs/xev_threadpool.3.scd
@@ -156,7 +156,7 @@ aligned.
 
 xev(7), xev-c(7)
 
-<https://zig.news/kprotty/resource-efficient-thread-pools-with-zig-3291>
+<https://kprotty.me/2021/09/12/resource-efficient-thread-pools-with-zig.html>
 
 <https://github.com/mitchellh/libxev>
 

--- a/src/ThreadPool.zig
+++ b/src/ThreadPool.zig
@@ -33,7 +33,7 @@
 //! SOFTWARE.
 //!
 //! [1]: https://github.com/kprotty/zap
-//! [2]: https://zig.news/kprotty/resource-efficient-thread-pools-with-zig-3291
+//! [2]: https://kprotty.me/2021/09/12/resource-efficient-thread-pools-with-zig.html
 const ThreadPool = @This();
 
 const std = @import("std");


### PR DESCRIPTION
- https://zig.news/kprotty/resource-efficient-thread-pools-with-zig-3291 is dead, replaced with https://kprotty.me/2021/09/12/resource-efficient-thread-pools-with-zig.html