### PR TITLE
kqueue: register mach-port wakeups on every Darwin target (iOS never woke)

### DIFF
--- a/src/backend/kqueue.zig
+++ b/src/backend/kqueue.zig
@@ -954,7 +954,7 @@ pub const Loop = struct {
         // Add to our completion queue
         c.task_loop.thread_pool_completions.push(c);
 
-        if (comptime builtin.target.os.tag == .macos) {
+        if (comptime builtin.target.os.tag.isDarwin()) {
             // Wake up our main loop
             c.task_loop.wakeup() catch {};
         }
@@ -1070,7 +1070,10 @@ pub const Completion = struct {
                 .udata = @intFromPtr(self),
             }),
 
-            .machport => if (comptime builtin.os.tag != .macos) return null else kevent: {
+            // Every Darwin target, not just macOS: Async is a mach port on
+            // all of them (watcher/async.zig picks by isDarwin), and iOS
+            // silently never registered its wakeups here.
+            .machport => if (comptime !builtin.os.tag.isDarwin()) return null else kevent: {
                 // We can't use |*v| above because it crahses the Zig
                 // compiler (as of 0.11.0-dev.1413). We can retry another time.
                 const v = &self.op.machport;


### PR DESCRIPTION
\`watcher/async.zig\` selects the mach-port \`Async\` implementation for every Darwin target (\`builtin.target.os.tag.isDarwin()\`), but \`backend/kqueue.zig\` only emitted the \`EVFILT_MACHPORT\` kevent for a \`.machport\` operation, and only woke the loop from the thread pool, when \`os.tag == .macos\`.

On iOS the result is silent: every \`Async.wait\` returns without registering anything, so \`notify()\` succeeds and nothing ever fires. In Ghostty's iOS build that meant the renderer never drew its first frame, the io thread never woke for its mailbox, and \`stop\` never stopped a loop (\`pthread_join\` hang on surface teardown). Verified on an iPhone 17 Pro / iOS 26: a direct \`EVFILT_MACHPORT\` registration wakes fine there, so the gate was the only thing in the way.

This widens both gates to \`isDarwin()\`. No behaviour change on macOS.